### PR TITLE
Match new[] with delete[] in Larson

### DIFF
--- a/bench/larson/larson.cpp
+++ b/bench/larson/larson.cpp
@@ -126,7 +126,7 @@ void * operator new( unsigned int cb )
   return pRet;
 }
 
-void operator delete(void *pUserData )
+void operator delete[](void *pUserData )
 {
   theFastHeap.Delete (pUserData) ;
 }
@@ -142,7 +142,7 @@ void * operator new( unsigned int cb )
   return pRet;
 }
 
-void operator delete(void *pUserData )
+void operator delete[](void *pUserData )
 {
   hdfree(pUserData) ;
 }
@@ -388,7 +388,7 @@ void runloops(long sleep_cnt, int num_chunks )
     for( cblks=0; cblks<num_chunks; cblks++){
       victim = lran2(&rgen)%num_chunks ;
 #if defined(CPP)
-    delete blkp[victim] ;
+    delete[] blkp[victim] ;
 #elif defined(USE_MALLOC)
     free(blkp[victim]);
 #else
@@ -592,7 +592,7 @@ static void * exercise_heap( void *pinput)
   for( cblks=0; cblks<pdea->NumBlocks; cblks++){
     victim = lran2(&pdea->rgen)%pdea->asize ;
 #ifdef CPP
-    delete pdea->array[victim] ;
+    delete[] pdea->array[victim] ;
 #else
     CUSTOM_FREE(pdea->array[victim]) ;
 #endif
@@ -682,7 +682,7 @@ static void warmup(char **blkp, int num_chunks )
   for( cblks=0; cblks<4*num_chunks; cblks++){
     victim = lran2(&rgen)%num_chunks ;
 #ifdef CPP
-    delete blkp[victim] ;
+    delete[] blkp[victim] ;
 #else
     CUSTOM_FREE(blkp[victim]) ;
 #endif


### PR DESCRIPTION
Larson benchmark is allocating arrays, but deallocating them as single objects. This is not standards compliant, and can lead to sized deallocations being called with the element size, rather than the array size (or unknown size).