### PR TITLE
Add IsolationAlloc to build and benchmark scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Supported allocators are:
 - **tbb**: The Intel [TBB](https://github.com/intel/tbb) allocator that comes with
   the Thread Building Blocks (TBB) library \[7].
   Installed as package `libtbb-dev`, version `2017~U7-8`.
-
+- **ia**: [Isolation Alloc](https://github.com/struct/isoalloc) by Chris Rohlf
+  is a general purpose allocator that primarily relies on an isolation strategy to
+  mitigate memory safety vulnerabilities. Tests use git master.
 
 ## Current Benchmarks
 

--- a/bench.sh
+++ b/bench.sh
@@ -14,6 +14,7 @@ run_smi=0
 run_xmi=0
 run_xdmi=0
 run_xsmi=0
+run_ia=0
 
 run_tc=0
 run_hd=0
@@ -105,6 +106,7 @@ lib_tlsf="${localdevdir}/tlsf/out/release/libtlsf.so"
 lib_tc="$localdevdir/gperftools/.libs/libtcmalloc_minimal.so"
 lib_tbb="`find $localdevdir/tbb/build -name libtbbmalloc_proxy.so.*`"
 lib_sc="$localdevdir/scalloc/out/Release/lib.target/libscalloc.so"
+lib_ia="$localdevdir/IsoAlloc/build/libisoalloc.so"
 
 if test "$use_packages" = "1"; then
   lib_tc="/usr/lib/libtcmalloc.so"
@@ -145,6 +147,7 @@ while : ; do
         run_rp=1
         #run_sm=1
         #run_sc=1
+	run_ia=1
         run_sn=1
         run_hd=1
         run_mesh=1
@@ -198,6 +201,8 @@ while : ; do
         run_hd=1;;
     tbb)
         run_tbb=1;;
+    ia)
+        run_ia=1;;
     mesh)
         run_mesh=1;;
     nomesh)
@@ -277,6 +282,7 @@ while : ; do
         echo "  sc                           use scalloc"
         echo "  rp                           use rpmalloc"
         echo "  tbb                          use Intel TBB malloc"
+	echo "  ia                           use IsoAlloc"
         echo "  sys                          use system malloc (glibc)"
         echo "  dmi                          use debug version of mimalloc"
         echo "  smi                          use secure version of mimalloc"
@@ -458,6 +464,12 @@ function run_je_test {
   fi
 }
 
+function run_ia_test {
+  if test "$run_ia" = "1"; then
+    run_testx $1 "ia" "${ldpreload}=$lib_ia" "$2"
+  fi
+}
+
 function run_tc_test {
   if test "$run_tc" = "1"; then
     run_testx $1 "tc" "${ldpreload}=$lib_tc" "$2"
@@ -537,6 +549,7 @@ function run_test {
   run_smi_test $1 "$2"
   run_tc_test $1 "$2"
   run_je_test $1 "$2"
+  run_ia_test $1 "$2"
   run_tbb_test $1 "$2"
   run_sm_test $1 "$2"
   run_sc_test $1 "$2"

--- a/bench.sh
+++ b/bench.sh
@@ -147,7 +147,7 @@ while : ; do
         run_rp=1
         #run_sm=1
         #run_sc=1
-	run_ia=1
+        run_ia=1
         run_sn=1
         run_hd=1
         run_mesh=1

--- a/bench.sh
+++ b/bench.sh
@@ -282,7 +282,7 @@ while : ; do
         echo "  sc                           use scalloc"
         echo "  rp                           use rpmalloc"
         echo "  tbb                          use Intel TBB malloc"
-	echo "  ia                           use IsoAlloc"
+        echo "  ia                           use IsoAlloc"
         echo "  sys                          use system malloc (glibc)"
         echo "  dmi                          use debug version of mimalloc"
         echo "  smi                          use secure version of mimalloc"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -67,7 +67,7 @@ while : ; do
         setup_rp=$flag_arg
         setup_hd=$flag_arg
         setup_sm=$flag_arg
-	setup_ia=$flag_arg
+        setup_ia=$flag_arg
         setup_tbb=$flag_arg
         setup_mesh=$flag_arg
 	# only run Mesh's 'nomesh' configuration if asked

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -19,6 +19,7 @@ version_tbb=2020
 version_mesh=67ff31acae
 version_nomesh=67ff31acae
 version_sc=master
+version_ia=master
 
 # allocators
 setup_je=0
@@ -32,6 +33,7 @@ setup_tbb=0
 setup_mesh=0
 setup_nomesh=0
 setup_sc=0
+setup_ia=0
 
 # bigger benchmarks
 setup_lean=0
@@ -65,6 +67,7 @@ while : ; do
         setup_rp=$flag_arg
         setup_hd=$flag_arg
         setup_sm=$flag_arg
+	setup_ia=$flag_arg
         setup_tbb=$flag_arg
         setup_mesh=$flag_arg
 	# only run Mesh's 'nomesh' configuration if asked
@@ -94,6 +97,8 @@ while : ; do
         setup_hd=$flag_arg;;
     tbb)
         setup_tbb=$flag_arg;;
+    ia)
+        setup_ia=$flag_arg;;
     mesh)
         setup_mesh=$flag_arg;;
     nomesh)
@@ -134,6 +139,7 @@ while : ; do
         echo "  sn                           setup snmalloc ($version_sn)"
         echo "  rp                           setup rpmalloc ($version_rp)"
         echo "  sc                           setup scalloc ($version_sc)"
+        echo "  ia                           setup IsoAlloc ($version_ia)"
         echo ""
         echo "  lean                         setup lean 3 benchmark"
         echo "  redis                        setup redis benchmark"
@@ -302,6 +308,12 @@ if test "$setup_sm" = "1"; then
   sed -i "s/-Werror//" Makefile.include
   cd release
   make
+  popd
+fi
+
+if test "$setup_ia" = "1"; then
+  checkout ia $version_ia IsoAlloc https://github.com/struct/IsoAlloc.git
+  make library
   popd
 fi
 


### PR DESCRIPTION
This PR adds support for https://github.com/struct/isoalloc to both the build and benchmark scripts. It pulls and builds master from github.