### PR TITLE
Alter number of threads for xmalloc-test

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -604,7 +604,7 @@ if test "$run_sh8bench" = "1"; then
   run_test "sh8benchN" "./sh8bench $procs"
 fi
 if test "$run_xmalloc_test" = "1"; then
-  tds=`echo "2*$procs" | bc`
+  tds=`echo "$procs/2" | bc`
   run_test "xmalloc-testN" "./xmalloc-test -w $tds -t 5 -s 64"
   #run_test "xmalloc-fixedN" "./xmalloc-test -w 100 -t 5 -s 128"
 fi

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -10,9 +10,9 @@ all=0
 # allocator versions
 version_je=5.2.1
 version_tc=gperftools-2.7
-version_sn=0.4.1
-version_mi=v1.6.4
-version_rp=1.4.0
+version_sn=0.5.2
+version_mi=v1.6.7
+version_rp=1.4.1
 version_hd=9d137ef37
 version_sm=709663f
 version_tbb=2020


### PR DESCRIPTION
xmalloc-test takes a parameter for the number of worker threads, `-w N`,
there are two types of threads `allocators` and `releasers`, and it will
allocator the parameters worth of each, i.e. `N`:

https://github.com/daanx/mimalloc-bench/blob/cfc24eb65d9982a5a9b5901df3c021a9ae93b60c/bench/xmalloc-test/xmalloc-test.c#L176-L190

So you expect for an optimal configuration to use
```
  -w {processors/2}
```
as the workers parameter for this benchmark.  The test is currently
configured to use
```
  -w {processors * 2}
```
workers, and thus `(processors * 4)` threads.

This PR changes it to uses the same number of threads as processors.

I have also updated the allocators I was looking at to the latest versions.