### PR TITLE
Add isoalloc

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -7,6 +7,7 @@ echo ""
 
 procs=8
 
+run_iso=0
 run_je=0
 run_mi=0
 run_dmi=0
@@ -117,6 +118,7 @@ lib_tc="$localdevdir/gperftools/.libs/libtcmalloc_minimal$extso"
 lib_sc="$localdevdir/scalloc/out/Release/lib.target/libscalloc$extso"
 lib_tbb="`find $localdevdir/tbb/build -name libtbbmalloc_proxy$extso.2`"
 lib_tbb_dir="$(dirname $lib_tbb)"
+lib_iso="${localdevdir}/iso/build/libisoalloc$extso"
 
 if test "$use_packages" = "1"; then
   lib_tc="/usr/lib/libtcmalloc$extso"
@@ -148,6 +150,7 @@ while : ; do
   case "$flag" in
     "") break;;
     alla)
+        run_mi=1
         run_mi=1
         run_smi=1
         #run_dmi=1
@@ -184,6 +187,8 @@ while : ; do
         # run_cthrash=1
         # run_malloc_test=1
         ;;
+    iso)
+        run_iso=1;;
     je)
         run_je=1;;
     rp)
@@ -282,6 +287,7 @@ while : ; do
         echo "  --verbose                    be verbose"
         echo "  --procs=<n>                  number of processors (=$procs)"
         echo ""
+        echo "  iso                          use isoalloc"
         echo "  je                           use jemalloc"
         echo "  tc                           use tcmalloc"
         echo "  mi                           use mimalloc"
@@ -520,6 +526,12 @@ function run_sc_test {
   fi
 }
 
+function run_iso_test {
+  if test "$run_iso" = "1"; then
+    run_testx $1 "iso" "${ldpreload}=$lib_iso" "$2"
+  fi
+}
+
 function run_tbb_test {
   if test "$run_tbb" = "1"; then
     run_testx $1 "tbb" "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$lib_tbb_dir ${ldpreload}=$lib_tbb" "$2"
@@ -542,6 +554,7 @@ function run_test {
   echo "      " >> $benchres
   echo ""
   echo "---- $1"
+  run_iso_test $1 "$2"
   run_sys_test $1 "$2"
   run_xmi_test $1 "$2"
   run_xdmi_test $1 "$2"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -15,6 +15,7 @@ rebuild=0
 all=0
 
 # allocator versions
+version_iso=master
 version_je=5.2.1
 version_tc=gperftools-2.8.1
 version_sn=0.5.3
@@ -29,6 +30,7 @@ version_sc=master
 version_redis=6.0.9
 
 # allocators
+setup_iso=0
 setup_je=0
 setup_tc=0
 setup_sn=0
@@ -66,6 +68,7 @@ while : ; do
     "") break;;
     all|none)
         all=$flag_arg
+        setup_iso=$flag_arg                
         setup_je=$flag_arg
         setup_tc=$flag_arg
         setup_sn=$flag_arg
@@ -86,6 +89,8 @@ while : ; do
         #setup_ch=$flag_arg
         setup_packages=$flag_arg
         ;;
+    iso)
+        setup_iso=$flag_arg;;
     je)
         setup_je=$flag_arg;;
     tc)
@@ -133,6 +138,7 @@ while : ; do
         echo "  --procs=<n>                  number of processors (=$procs)"
         echo "  --rebuild                    force re-clone and re-build for given tools"
         echo ""
+        echo "  iso                          setup isoalloc ($version_iso)"
         echo "  je                           setup jemalloc ($version_je)"
         echo "  tc                           setup tcmalloc ($version_tc)"
         echo "  mi                           setup mimalloc ($version_mi)"
@@ -250,6 +256,12 @@ if test "$setup_packages" = "1"; then
     aptinstall "g++ clang llvm-dev unzip dos2unix linuxinfo bc libgmp-dev wget"
     aptinstall "cmake python ruby ninja-build libtool autoconf"
   fi
+fi
+
+if test "$setup_iso" = "1"; then
+  checkout iso $version_iso iso https://github.com/struct/isoalloc
+  make library
+  popd
 fi
 
 if test "$setup_tbb" = "1"; then


### PR DESCRIPTION
This commit adds [isoalloc]( https://github.com/struct/isoalloc ) and is based on 1b99ea2b8ce6ec0b23ad831aa86a84843155d9b5

Tested like this:

```
$ ../../bench.sh cfrac iso je
--- Benchmarking ---

Running on 2 cores.
Installed allocators:

iso:  master,  209d9d7,  https://github.com/struct/isoalloc
je:   5.2.1,   ea6b3e9,  https://github.com/jemalloc/jemalloc.git


---- cfrac

run cfrac iso: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/iso/build/libisoalloc.so ./cfrac 17545186520507317056371138836327483792789528
cfrac iso 0:13.75 15264 13.63 0.12 0 3435

run cfrac je: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/jemalloc/lib/libjemalloc.so ./cfrac 17545186520507317056371138836327483792789528
cfrac je 0:07.79 4752 7.76 0.00 0 470

# --------------------------------------------------
# benchmark allocator elapsed rss user sys page-faults page-reclaims
      
cfrac iso 13.75 15264 13.63 0.12 0 3435
cfrac je 07.79 4752 7.76 0.00 0 470
```

Cc @struct