### PR TITLE
Add hardened_malloc

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -7,6 +7,7 @@ echo ""
 
 procs=8
 
+run_hm=0
 run_iso=0
 run_je=0
 run_mi=0
@@ -119,6 +120,7 @@ lib_sc="$localdevdir/scalloc/out/Release/lib.target/libscalloc$extso"
 lib_tbb="`find $localdevdir/tbb/build -name libtbbmalloc_proxy$extso.2`"
 lib_tbb_dir="$(dirname $lib_tbb)"
 lib_iso="${localdevdir}/iso/build/libisoalloc$extso"
+lib_hm="${localdevdir}/hm/libhardened_malloc$extso"
 
 if test "$use_packages" = "1"; then
   lib_tc="/usr/lib/libtcmalloc$extso"
@@ -150,6 +152,7 @@ while : ; do
   case "$flag" in
     "") break;;
     alla)
+        run_hm=1
         run_mi=1
         run_mi=1
         run_smi=1
@@ -187,6 +190,8 @@ while : ; do
         # run_cthrash=1
         # run_malloc_test=1
         ;;
+    hm)
+        run_hm=1;;
     iso)
         run_iso=1;;
     je)
@@ -287,6 +292,7 @@ while : ; do
         echo "  --verbose                    be verbose"
         echo "  --procs=<n>                  number of processors (=$procs)"
         echo ""
+        echo "  hm                           use hardened_malloc"
         echo "  iso                          use isoalloc"
         echo "  je                           use jemalloc"
         echo "  tc                           use tcmalloc"
@@ -526,6 +532,13 @@ function run_sc_test {
   fi
 }
 
+function run_hm_test {
+  if test "$run_hm" = "1"; then
+    run_testx $1 "hm" "${ldpreload}=$lib_hm" "$2"
+  fi
+}
+
+
 function run_iso_test {
   if test "$run_iso" = "1"; then
     run_testx $1 "iso" "${ldpreload}=$lib_iso" "$2"
@@ -554,6 +567,7 @@ function run_test {
   echo "      " >> $benchres
   echo ""
   echo "---- $1"
+  run_hm_test $1 "$2"
   run_iso_test $1 "$2"
   run_sys_test $1 "$2"
   run_xmi_test $1 "$2"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -15,6 +15,7 @@ rebuild=0
 all=0
 
 # allocator versions
+version_hm=main
 version_iso=master
 version_je=5.2.1
 version_tc=gperftools-2.9.1
@@ -30,6 +31,7 @@ version_sc=master
 version_redis=6.0.9
 
 # allocators
+setup_hm=0
 setup_iso=0
 setup_je=0
 setup_tc=0
@@ -68,6 +70,7 @@ while : ; do
     "") break;;
     all|none)
         all=$flag_arg
+        setup_hm=$flag_arg                
         setup_iso=$flag_arg                
         setup_je=$flag_arg
         setup_tc=$flag_arg
@@ -89,6 +92,8 @@ while : ; do
         #setup_ch=$flag_arg
         setup_packages=$flag_arg
         ;;
+    hm)
+        setup_hm=$flag_arg;;
     iso)
         setup_iso=$flag_arg;;
     je)
@@ -138,6 +143,7 @@ while : ; do
         echo "  --procs=<n>                  number of processors (=$procs)"
         echo "  --rebuild                    force re-clone and re-build for given tools"
         echo ""
+        echo "  hm                           setup hardened_malloc ($version_hm)"
         echo "  iso                          setup isoalloc ($version_iso)"
         echo "  je                           setup jemalloc ($version_je)"
         echo "  tc                           setup tcmalloc ($version_tc)"
@@ -256,6 +262,12 @@ if test "$setup_packages" = "1"; then
     aptinstall "g++ clang llvm-dev unzip dos2unix linuxinfo bc libgmp-dev wget"
     aptinstall "cmake python ruby ninja-build libtool autoconf"
   fi
+fi
+
+if test "$setup_hm" = "1"; then
+  checkout hm $version_hm hm https://github.com/GrapheneOS/hardened_malloc
+  make 
+  popd
 fi
 
 if test "$setup_iso" = "1"; then


### PR DESCRIPTION
This commit adds [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc) and is based on #31

Tested like this:

```
$ ../../bench.sh hm je cfrac
--- Benchmarking ---
Running on 2 cores.
Installed allocators:

hm:   main,    aa94408,  https://github.com/GrapheneOS/hardened_malloc
je:   5.2.1,   ea6b3e9,  https://github.com/jemalloc/jemalloc.git

---- cfrac

run cfrac hm: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/hm/libhardened_malloc.so ./cfrac 17545186520507317056371138836327483792789528
cfrac hm 0:13.17 6508 13.14 0.01 0 1069

run cfrac je: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/jemalloc/lib/libjemalloc.so ./cfrac 17545186520507317056371138836327483792789528
cfrac je 0:07.77 4828 7.73 0.00 0 474

# --------------------------------------------------
# benchmark allocator elapsed rss user sys page-faults page-reclaims
      
cfrac hm 13.17 6508 13.14 0.01 0 1069
cfrac je 07.77 4828 7.73 0.00 0 474
```

cc @thestinger