### PR TITLE
Add a github action

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,0 +1,15 @@
+name: Build and run everything
+on: [push, pull_request]
+jobs:
+  build-all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install and build all benchmarks and allocators
+        run: ./build-bench-env.sh all
+      - name: Run everything.
+        run: |
+          cd out/bench
+          ../../bench.sh alla allt
+


### PR DESCRIPTION
Having a CI is nice, so let's have one.

This already uncovered a couple of issues:

- `tcmalloc` take ages to build, since we're building its benchmarks and huge pile of tests 
- same remark for `snmalloc`
- the number of cores is hardcoded to `4` instead of being detected at runtime
- the `lean` benchmark spits a ton of warnings, bloating the build log
- `./build-bench-env.sh all` doesn't build `mesh` with meshing disabled, yet `../../bench.sh alla allt` is trying to run it, resulting in an error: `ERROR: ld.so: object '/home/runner/work/mimalloc-bench/mimalloc-bench/extern/nomesh/libmesh.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.`, preventing us to make the CI fail upon errors.
- looking for tbb fails with:

```
find: ‘/home/runner/work/mimalloc-bench/mimalloc-bench/extern/tbb/build’: No such file or directory
dirname: missing operand
Try 'dirname --help' for more information.
```