### PR TITLE
Bump mesh version

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -33,8 +33,8 @@ version_hm=main
 version_iso=1.0.0
 version_hd=5afe855 # 3.13 #a43ac40 #d880f72  #9d137ef37
 version_sm=709663f
-version_mesh=78b9b5d
-version_nomesh=78b9b5d
+version_mesh=7ef171c7870c8da1c52ff3d78482421f46beb94c
+version_nomesh=7ef171c7870c8da1c52ff3d78482421f46beb94c
 version_sc=v1.0.0
 version_redis=6.0.9
 


### PR DESCRIPTION
So that we can have https://github.com/plasma-umass/Mesh/pull/88
which is a prerequisite for https://github.com/daanx/mimalloc-bench/pull/47