### PR TITLE
Bump TBB and enable it on musl

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -17,10 +17,9 @@ jobs:
       - name: Install and build all benchmarks and allocators
         # hd: glibc-specific
         # dieharder: glibc-specific
-        # tbb: needs RTLD_DEEPBIND, but it doesn't exist on musl
         # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
         # mesh/nomesh: there is an infinite loop in the somewhere
-        run: ./build-bench-env.sh all no-dh no-hd no-tbb no-sm no-mesh no-nomesh
+        run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh
       - name: Run everything.
         run: |
           cd out/bench

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -38,7 +38,7 @@ version_sc=v1.0.0
 version_scudo=main
 version_sm=709663f
 version_sn=0.5.3
-version_tbb=v2021.4.0 # v2020.3
+version_tbb=883c2e5245c39624b3b5d6d56d5b203cf09eac38  # needed for musl
 version_tc=gperftools-2.9.1
 
 # benchmark versions
@@ -366,8 +366,7 @@ fi
 
 if test "$setup_tbb" = "1"; then
   checkout tbb $version_tbb tbb https://github.com/intel/tbb
-  # make tbbmalloc
-  cmake -DCMAKE_BUILD_TYPE=Release -DTBB_BUILD=OFF -DTBB_TEST=OFF -DTBB_OUTPUT_DIR_BASE=bench
+  cmake -DCMAKE_BUILD_TYPE=Release -DTBB_BUILD=OFF -DTBB_TEST=OFF -DTBB_OUTPUT_DIR_BASE=bench -DTBBMALLOC_PROXY_BUILD=OFF .
   make -j $procs
   popd
 fi


### PR DESCRIPTION
We can't use the XXX stable release because we need:
- https://github.com/oneapi-src/oneTBB/pull/604 ­—  CMake: disable build of tbbmalloc_proxy on Windows ARM64, since the proxy thingy can't be built on musl
- https://github.com/oneapi-src/oneTBB/pull/684 —  Musl/linux can not use RTLD_DEEPBIND