### PR TITLE
Add a sed-based benchmark

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -110,7 +110,7 @@ while : ; do
         if [ -z "$darwin" ]; then
           setup_tcg=$flag_arg     # error: unknown warning option '-Wno-attribute-alias' […] unknown warning option '-Wno-stringop-overflow'; did you mean '-Wno-shift-overflow'?
           setup_dh=$flag_arg        
-          setup_mng=$flag_arg   # lacking getentropy()
+          setup_mng=$flag_arg       # lacking getentropy()
           setup_hm=$flag_arg        # lacking <thread.h>
           setup_mesh=$flag_arg          
           setup_rp=$flag_arg
@@ -118,7 +118,7 @@ while : ; do
           setup_sm=$flag_arg
         else
           if ! [ `uname -m` = "x86_64" ]; then
-            setup_dh=$flag_arg   # does not compile on macos x64
+            setup_dh=$flag_arg      # does not compile on macos x64
           fi
         fi        
         # only run Mesh's 'nomesh' configuration if asked
@@ -360,20 +360,20 @@ if test "$setup_packages" = "1"; then
   if grep -q 'ID=fedora' /etc/os-release 2>/dev/null; then
     # no 'apt update' equivalent needed on Fedora
     dnfinstall "gcc-c++ clang lld llvm-devel unzip dos2unix bc gmp-devel wget gawk"
-    dnfinstall "cmake python3 ruby ninja-build libtool autoconf git patch time"
+    dnfinstall "cmake python3 ruby ninja-build libtool autoconf git patch time sed"
     dnfinstallbazel
   elif grep -q -e 'ID=debian' -e 'ID=ubuntu' /etc/os-release 2>/dev/null; then
     echo "updating package database... (sudo apt update)"
     sudo apt update -qq
     aptinstall "g++ clang lld llvm-dev unzip dos2unix linuxinfo bc libgmp-dev wget"
-    aptinstall "cmake python3 ruby ninja-build libtool autoconf  gawk"
+    aptinstall "cmake python3 ruby ninja-build libtool autoconf sed"
     aptinstallbazel
   elif grep -q -e 'ID=alpine' /etc/os-release 2>/dev/null; then
     apk update
     apkinstall "clang lld unzip dos2unix bc gmp-dev wget cmake python3 automake gawk"
-    apkinstall "samurai libtool git build-base linux-headers autoconf util-linux"
+    apkinstall "samurai libtool git build-base linux-headers autoconf util-linux sed"
   elif brew --version 2> /dev/null >/dev/null; then
-    brewinstall "dos2unix wget cmake ninja automake libtool gnu-time gmp mpir gawk bazelisk"
+    brewinstall "dos2unix wget cmake ninja automake libtool gnu-time gmp mpir gnu-sed bazelisk"
   fi
 fi
 


### PR DESCRIPTION
This triggers a lot of variously-sized
variously-lived allocations/reallocations.

```
$ ltrace -e malloc -e realloc -e calloc sed -i -E -n '/^((.|.?){256}(.|.?)?(.|.?)){12}/p' /etc/motd 2>&1 | wc -
150819
$
```