### PR TITLE
Add benchmarks versions to bench.sh script

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -32,6 +32,12 @@ tests_run=""
 tests_exclude=""
 readonly tests_exclude_macos="sh6bench sh8bench redis"
 
+# --------------------------------------------------------------------
+# benchmark versions
+# --------------------------------------------------------------------
+
+readonly version_redis=6.2.7
+readonly version_rocksdb=7.3.1
 
 # --------------------------------------------------------------------
 # Environment
@@ -149,9 +155,9 @@ fi
 
 readonly leandir="$localdevdir/lean"
 readonly leanmldir="$leandir/../mathlib"
-readonly redis_dir="$localdevdir/redis-6.2.7/src"
+readonly redis_dir="$localdevdir/redis-$version_redis/src"
 readonly pdfdoc="$localdevdir/large.pdf" 
-readonly rocksdb_dir="$localdevdir/rocksdb-7.3.1"
+readonly rocksdb_dir="$localdevdir/rocksdb-$version_rocksdb"
 
 readonly spec_dir="$localdevdir/../../spec2017"
 readonly spec_base="base"


### PR DESCRIPTION
Small refactoring with benchmark versions that uses the same way as in build-bench-env.sh