### PR TITLE
Add a prototype of security benchmark

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -110,3 +110,8 @@ target_link_libraries(glibc-simple pthread)
 
 add_executable(glibc-thread glibc-bench/bench-malloc-thread.c)
 target_link_libraries(glibc-thread pthread)
+
+file(GLOB MY_SECURITY_BINARIES
+  "security/*"
+)
+file(COPY ${MY_SECURITY_BINARIES} DESTINATION security/)

--- a/bench/security/Makefile
+++ b/bench/security/Makefile
@@ -1,0 +1,12 @@
+CFLAGS := -Wno-free-nonheap-object
+
+SRCS = $(wildcard *.c)
+PROGS = $(patsubst %.c,%,$(SRCS))
+
+%: %.c
+	$(CC) $(CFLAGS)  -o $@ $<
+
+all: $(PROGS)
+
+clean:
+	rm -rf $(PROGS)

--- a/bench/security/double_free_large.c
+++ b/bench/security/double_free_large.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(256 * 1024);
+    free(p);
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/double_free_large_delayed.c
+++ b/bench/security/double_free_large_delayed.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(256 * 1024);
+    free(p);
+
+    for(int i=0; i<1024; i++)
+        free(malloc(256 * 1024));
+
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/double_free_large_interleaved.c
+++ b/bench/security/double_free_large_interleaved.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(256 * 1024);
+    void *q = malloc(256 * 1024);
+    free(p);
+    free(q);
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/double_free_small.c
+++ b/bench/security/double_free_small.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(8);
+    free(p);
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/double_free_small_delayed.c
+++ b/bench/security/double_free_small_delayed.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(8);
+    free(p);
+
+    for(int i=0; i<1024; i++)
+        free(malloc(8));
+
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/double_free_small_interleaved.c
+++ b/bench/security/double_free_small_interleaved.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    void *p = malloc(8);
+    void *q = malloc(8);
+    free(p);
+    free(q);
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/executable_heap.c
+++ b/bench/security/executable_heap.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+const char* shellcode = "\x90\x90\x90\x90\xc3";  // nop, ..., ret on x86
+
+int main(void) {
+    char *p = malloc(8);
+    memcpy(p, shellcode, sizeof(shellcode));
+    void(*fptr)(void) = (void(*)(void))p;
+    fptr();
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/invalid_free.c
+++ b/bench/security/invalid_free.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    free((void *)1);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/invalid_free_alloca.c
+++ b/bench/security/invalid_free_alloca.c
@@ -1,0 +1,9 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    free(alloca(8));
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/invalid_free_stack.c
+++ b/bench/security/invalid_free_stack.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    char p[8];
+    free(p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/malloc_reuse.c
+++ b/bench/security/malloc_reuse.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+/* This test checks that pointers aren't immediately re-used between
+ * allocations. */
+
+int main(void) {
+    void *p = malloc(8);
+    void *q = p;
+    free(p);
+
+    p = malloc(8);
+
+    if (p == q)
+	    puts("NOT_CAUGHT");
+
+    return 0;
+}

--- a/bench/security/one_byte_underflow_big.c
+++ b/bench/security/one_byte_underflow_big.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    char *p = malloc(256 * 1024);
+    p[-1] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
+    free(p);
+
+    puts("NOT_CAUGHT");
+
+    return 0;
+}

--- a/bench/security/one_byte_underflow_small.c
+++ b/bench/security/one_byte_underflow_small.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    char *p = malloc(8);
+    p[-1] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
+    free(p);
+
+    puts("NOT_CAUGHT");
+
+    return 0;
+}

--- a/bench/security/read_zero_size.c
+++ b/bench/security/read_zero_size.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+    char *p = malloc(0);
+    if (!p) {
+        return 1;
+    }
+    putchar(*p);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/unaligned_free_large.c
+++ b/bench/security/unaligned_free_large.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+    char *p = malloc(256 * 1024);
+    free(p + 1);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/unaligned_free_small.c
+++ b/bench/security/unaligned_free_small.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+    char *p = malloc(8);
+    free(p + 1);
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/write_after_free_large.c
+++ b/bench/security/write_after_free_large.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(256 * 1024);
+    free(p);
+    memset(p, 'A', 256 * 1024);
+
+    puts("NOT_CAUGHT");
+
+    return 0;
+}

--- a/bench/security/write_after_free_small.c
+++ b/bench/security/write_after_free_small.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(8);
+    free(p);
+    memset(p, 'A', 8);
+
+    puts("NOT_CAUGHT");
+
+    return 0;
+}

--- a/bench/security/write_zero_size.c
+++ b/bench/security/write_zero_size.c
@@ -1,0 +1,13 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main() {
+    char *p = malloc(0);
+    if (!p) {
+        return 1;
+    }
+    *p = 'A';
+
+    puts("NOT_CAUGHT");
+    return 0;
+}

--- a/bench/security/zero_after_free_large.c
+++ b/bench/security/zero_after_free_large.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(256 * 1024);
+    memset(p, 'A', 256 * 1024);
+    free(p);
+
+    for (int i=0; i<256 * 1024; i++) {
+        if (p[i] != 0) {
+            puts("NOT_CAUGHT");
+            return 0;
+        }
+    }
+
+    return 0;
+}

--- a/bench/security/zero_after_free_small.c
+++ b/bench/security/zero_after_free_small.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(8);
+    memset(p, 'A', 8);
+    free(p);
+
+    for (int i=0; i<8; i++) {
+        if (p[i] != 0) {
+            puts("NOT_CAUGHT");
+            return 0;
+        }
+    }
+
+    return 0;
+}

--- a/bench/security/zero_on_malloc_large.c
+++ b/bench/security/zero_on_malloc_large.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(256 * 1024);
+    for (int i=0; i<256 * 1024; i++) {
+        if (p[i] != 0) {
+            puts("NOT_CAUGHT");
+            return 0;
+        }
+    }
+
+    return 0;
+}

--- a/bench/security/zero_on_malloc_small.c
+++ b/bench/security/zero_on_malloc_small.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void) {
+    char *p = malloc(8);
+
+    for (int i=0; i<8; i++) {
+        if (p[i] != 0) {
+            puts("NOT_CAUGHT");
+            return 0;
+        }
+    }
+
+    return 0;
+}

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -151,11 +151,14 @@ while : ; do
         setup_redis=$flag_arg
         setup_rocksdb=$flag_arg
         setup_bench=$flag_arg
+        setup_security=$flag_arg
         #setup_ch=$flag_arg
         setup_packages=$flag_arg
         ;;
     bench)
         setup_bench=$flag_arg;;
+    security)
+        setup_security=$flag_arg;;
     ch)
         setup_ch=$flag_arg;;
     ff)
@@ -739,6 +742,13 @@ if test "$setup_ch" = "1"; then
   phase "build ClickHouse v19.8.3.8-stable"
   checkout ClickHouse mimalloc ClickHouse https://github.com/yandex/ClickHouse "--recursive"
   ./release
+  popd
+fi
+
+if test "$setup_security" = "1"; then
+  phase "build the security benchmark"
+  pushd "bench/security"
+  make -j $procs
   popd
 fi
 


### PR DESCRIPTION
See #153 for details/motivation. It looks like this:

```
$ ~/dev/mimalloc-bench/out/bench ../../bench.sh security alla
benchmarking on 4096 cores.
use '-h' or '--help' for help on configuration options.

allocators:  sys iso mi mi-sec
tests     :  security
(excluded tests:  lean lean-mathlib)

---- 1: security

run 1: security sys: SYSMALLOC=1 

run 1: security iso: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/iso/build/libisoalloc.so 

run 1: security mi: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/mimalloc/out/release/libmimalloc.so 

run 1: security mi-sec: LD_PRELOAD=/home/jvoisin/dev/mimalloc-bench/extern/mimalloc/out/secure/libmimalloc-secure.so 
iso
[+] security/double_free_large
[+] security/double_free_large_delayed
[+] security/double_free_large_interleaved
[+] security/double_free_small
[+] security/double_free_small_delayed
[+] security/double_free_small_interleaved
[+] security/executable_heap
[+] security/invalid_free_alloca
[+] security/invalid_free
[+] security/invalid_free_stack
[+] security/malloc_reuse
[+] security/one_byte_underflow_big
[-] security/one_byte_underflow_small
[+] security/read_zero_size
[+] security/unaligned_free_large
[+] security/unaligned_free_small
[-] security/use_after_free_large
[-] security/use_after_free_small
[+] security/write_zero_size
[-] security/zero_after_free_large
[-] security/zero_after_free_small
[+] security/zero_on_malloc_large
[+] security/zero_on_malloc_small

mi
[-] security/double_free_large
[-] security/double_free_large_delayed
[-] security/double_free_large_interleaved
[-] security/double_free_small
[-] security/double_free_small_delayed
[-] security/double_free_small_interleaved
[+] security/executable_heap
[+] security/invalid_free_alloca
[-] security/invalid_free
[+] security/invalid_free_stack
[+] security/malloc_reuse
[-] security/one_byte_underflow_big
[-] security/one_byte_underflow_small
[-] security/read_zero_size
[-] security/unaligned_free_large
[-] security/unaligned_free_small
[-] security/use_after_free_large
[-] security/use_after_free_small
[-] security/write_zero_size
[-] security/zero_after_free_large
[+] security/zero_after_free_small
[+] security/zero_on_malloc_large
[-] security/zero_on_malloc_small

mi-sec
[-] security/double_free_large
[-] security/double_free_large_delayed
[-] security/double_free_large_interleaved
[-] security/double_free_small
[-] security/double_free_small_delayed
[-] security/double_free_small_interleaved
[+] security/executable_heap
[-] security/invalid_free_alloca
[-] security/invalid_free
[-] security/invalid_free_stack
[+] security/malloc_reuse
[-] security/one_byte_underflow_big
[+] security/one_byte_underflow_small
[-] security/read_zero_size
[-] security/unaligned_free_large
[-] security/unaligned_free_small
[-] security/use_after_free_large
[-] security/use_after_free_small
[-] security/write_zero_size
[-] security/zero_after_free_large
[-] security/zero_after_free_small
[+] security/zero_on_malloc_large
[+] security/zero_on_malloc_small

sys
[+] security/double_free_large
[+] security/double_free_large_delayed
[+] security/double_free_large_interleaved
[+] security/double_free_small
[+] security/double_free_small_delayed
[+] security/double_free_small_interleaved
[+] security/executable_heap
[+] security/invalid_free_alloca
[+] security/invalid_free
[+] security/invalid_free_stack
[-] security/malloc_reuse
[-] security/one_byte_underflow_big
[-] security/one_byte_underflow_small
[-] security/read_zero_size
[+] security/unaligned_free_large
[+] security/unaligned_free_small
[+] security/use_after_free_large
[-] security/use_after_free_small
[-] security/write_zero_size
[+] security/zero_after_free_large
[-] security/zero_after_free_small
[-] security/zero_on_malloc_large
[-] security/zero_on_malloc_small

$ ~/dev/mimalloc-bench/out/bench 
```

cc @Maximus- @struct