### PR TITLE
Prevent memcpy from being inlined

### DIFF
--- a/bench/security/32_byte_memcpy_overflow.c
+++ b/bench/security/32_byte_memcpy_overflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE + 32] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p, c, sizeof(c));
+    memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();
 

--- a/bench/security/32_byte_memcpy_underflow.c
+++ b/bench/security/32_byte_memcpy_underflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p - 32, c, sizeof(c));
+    memcpy_noinline(p - 32, c, sizeof(c));
 
     NOT_CAUGHT();
 

--- a/bench/security/CMakeLists.txt
+++ b/bench/security/CMakeLists.txt
@@ -2,18 +2,22 @@ file(GLOB MY_SECURITY_TESTS
   "*.c"
 )
 
+macro (add_security_test test_name test_file allocation_size)
+  add_executable(${test_name} ${test_file})
+  target_compile_options(${test_name}  PRIVATE 
+    -Wno-free-nonheap-object 
+    -fno-inline
+    -fno-builtin-inline
+    -fno-inline-small-functions 
+    -DALLOCATION_SIZE=${allocation_size})
+endmacro ()
+
 foreach(f ${MY_SECURITY_TESTS})
   get_filename_component (exe_name ${f} NAME_WE)
-  set (exe_name_small  "${exe_name}_small")
-  set (exe_name_medium "${exe_name}_medium")
-  set (exe_name_large  "${exe_name}_large")
   message(STATUS "Compiling ${f} ${exe_name}")
-  add_executable(${exe_name_small} ${f})
-  add_executable(${exe_name_medium} ${f})
-  add_executable(${exe_name_large} ${f})
-  target_compile_options(${exe_name_small}  PRIVATE -Wno-free-nonheap-object -DALLOCATION_SIZE=8)
-  target_compile_options(${exe_name_medium} PRIVATE -Wno-free-nonheap-object -DALLOCATION_SIZE=4096)
-  target_compile_options(${exe_name_large}  PRIVATE -Wno-free-nonheap-object -DALLOCATION_SIZE=256*1024)
+  add_security_test("${exe_name}_small" ${f} 8)
+  add_security_test("${exe_name}_medium" ${f} 4096)
+  add_security_test("${exe_name}_large" ${f} 256*1024)
 endforeach()
 
 file(GLOB MY_SECURITY_TESTS_CPP

--- a/bench/security/common.h
+++ b/bench/security/common.h
@@ -7,4 +7,9 @@
 
 #define NOT_CAUGHT() do { puts("NOT_CAUGHT"); fflush(stdout); } while ((0));
 
+__attribute((noinline))
+void* memcpy_noinline(void* dest, const void* src, size_t n) {
+    return memcpy(dest, src, n);
+}
+
 #endif //_MIMALLOC_BENCH_SECURITY_COMMON_H

--- a/bench/security/common.h
+++ b/bench/security/common.h
@@ -7,7 +7,13 @@
 
 #define NOT_CAUGHT() do { puts("NOT_CAUGHT"); fflush(stdout); } while ((0));
 
+#if defined(_MSC_VER) 
+__declspec(noinline)
+#elif defined(__INTEL_COMPILER)
+#pragma noinline
+#else
 __attribute((noinline))
+#endif
 void* memcpy_noinline(void* dest, const void* src, size_t n) {
     return memcpy(dest, src, n);
 }

--- a/bench/security/one_byte_memcpy_overflow.c
+++ b/bench/security/one_byte_memcpy_overflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE + 1] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p, c, sizeof(c));
+    memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();
 

--- a/bench/security/one_byte_memcpy_underflow.c
+++ b/bench/security/one_byte_memcpy_underflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p - 1, c, sizeof(c));
+    memcpy_noinline(p - 1, c, sizeof(c));
 
     NOT_CAUGHT();
 

--- a/bench/security/one_mbyte_memcpy_overflow.c
+++ b/bench/security/one_mbyte_memcpy_overflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE + 1024 * 1024] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p, c, sizeof(c));
+    memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();
 

--- a/bench/security/one_mbyte_memcpy_underflow.c
+++ b/bench/security/one_mbyte_memcpy_underflow.c
@@ -8,7 +8,7 @@
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
     char *p = malloc(ALLOCATION_SIZE);
-    memcpy(p - 1024 * 1024, c, sizeof(c));
+    memcpy_noinline(p - 1024 * 1024, c, sizeof(c));
 
     NOT_CAUGHT();
 


### PR DESCRIPTION
The memcpy implementation can be inlined by the compiler.  This prevents
the snmalloc style guarded memcpy from being able to override the memcpy.
This forces it to be not inlined, and thus hopefully the compiler can't
remove the call.