### PR TITLE
Prevent malloc and free being inlined.

### DIFF
--- a/bench/security/32_byte_memcpy_overflow.c
+++ b/bench/security/32_byte_memcpy_overflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE + 32] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/32_byte_memcpy_underflow.c
+++ b/bench/security/32_byte_memcpy_underflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p - 32, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/32_byte_overflow.c
+++ b/bench/security/32_byte_overflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[ALLOCATION_SIZE - 1 + 32] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/32_byte_underflow.c
+++ b/bench/security/32_byte_underflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[-32] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/common.h
+++ b/bench/security/common.h
@@ -8,14 +8,26 @@
 #define NOT_CAUGHT() do { puts("NOT_CAUGHT"); fflush(stdout); } while ((0));
 
 #if defined(_MSC_VER) 
-__declspec(noinline)
+#define NOINLINE __declspec(noinline)
 #elif defined(__INTEL_COMPILER)
-#pragma noinline
+#define NOINLINE _Pragma("noinline")
 #else
-__attribute((noinline))
+#define NOINLINE __attribute((noinline))
 #endif
+
+NOINLINE
 void* memcpy_noinline(void* dest, const void* src, size_t n) {
     return memcpy(dest, src, n);
+}
+
+NOINLINE
+void* malloc_noinline(size_t size) {
+    return malloc(size);
+}
+
+NOINLINE
+void free_noinline(void* ptr) {
+    return free(ptr);
 }
 
 #endif //_MIMALLOC_BENCH_SECURITY_COMMON_H

--- a/bench/security/double_free.c
+++ b/bench/security/double_free.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main() {
-    void *p = malloc(ALLOCATION_SIZE);
-    free(p);
-    free(p);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/double_free_delayed.c
+++ b/bench/security/double_free_delayed.c
@@ -4,13 +4,13 @@
 #include "common.h"
 
 int main() {
-    void *p = malloc(ALLOCATION_SIZE);
-    free(p);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
 
     for(int i=0; i<1024; i++)
-        free(malloc(ALLOCATION_SIZE));
+        free_noinline(malloc_noinline(ALLOCATION_SIZE));
 
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/double_free_interleaved.c
+++ b/bench/security/double_free_interleaved.c
@@ -4,11 +4,11 @@
 #include "common.h"
 
 int main() {
-    void *p = malloc(ALLOCATION_SIZE);
-    void *q = malloc(ALLOCATION_SIZE);
-    free(p);
-    free(q);
-    free(p);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
+    void *q = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
+    free_noinline(q);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/double_free_reuse.c
+++ b/bench/security/double_free_reuse.c
@@ -3,13 +3,19 @@
 
 #include "common.h"
 
-int main() {
-    void *p = malloc(ALLOCATION_SIZE);
-    free(p);
-    free(p);
+int main()
+{
+    void *p = malloc_noinline(ALLOCATION_SIZE);
+    printf("p = %p", p);
+    free_noinline(p);
+    free_noinline(p);
 
-    for (size_t i=0; i< 1024 * 256; i++)
-        free(malloc(ALLOCATION_SIZE));
+    for (size_t i = 0; i < 1024 * 256; i++)
+    {
+        void *q = malloc_noinline(ALLOCATION_SIZE);
+        printf("q = %p", q);
+        free_noinline(q);
+    }
 
     NOT_CAUGHT();
 

--- a/bench/security/double_free_single_reuse.c
+++ b/bench/security/double_free_single_reuse.c
@@ -4,11 +4,11 @@
 #include "common.h"
 
 int main() {
-    void *p = malloc(ALLOCATION_SIZE);
-    free(p);
-    void *q = malloc(ALLOCATION_SIZE);
-    free(p);
-    free(q);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
+    void *q = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
+    free_noinline(q);
 
     NOT_CAUGHT();
 

--- a/bench/security/executable_heap.c
+++ b/bench/security/executable_heap.c
@@ -7,7 +7,7 @@
 const char* shellcode = "\x90\x90\x90\x90\xc3";  // nop, ..., ret on x86
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy(p, shellcode, sizeof(shellcode));
     void(*fptr)(void) = (void(*)(void))p;
     fptr();

--- a/bench/security/impossibly_large_malloc.c
+++ b/bench/security/impossibly_large_malloc.c
@@ -4,10 +4,10 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(-2);
+    char *p = malloc_noinline(-2);
     if (p != NULL) {
       NOT_CAUGHT();
     }
-    free(p);
+    free_noinline(p);
     return 0;
 }

--- a/bench/security/invalid_free.c
+++ b/bench/security/invalid_free.c
@@ -4,7 +4,7 @@
 #include "common.h"
 
 int main(void) {
-    free((void *)1);
+    free_noinline((void *)1);
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_alloca.c
+++ b/bench/security/invalid_free_alloca.c
@@ -4,7 +4,7 @@
 #include "common.h"
 
 int main(void) {
-    free(alloca(ALLOCATION_SIZE));
+    free_noinline(alloca(ALLOCATION_SIZE));
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_close.c
+++ b/bench/security/invalid_free_close.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     char* q = p + 4 * 1024;
-    free(q);
+    free_noinline(q);
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_far.c
+++ b/bench/security/invalid_free_far.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     char* q = p + 1024 * 1024 * 1024;
-    free(q);
+    free_noinline(q);
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_stack.c
+++ b/bench/security/invalid_free_stack.c
@@ -5,7 +5,7 @@
 
 int main(void) {
     char p[ALLOCATION_SIZE];
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_unaligned.c
+++ b/bench/security/invalid_free_unaligned.c
@@ -4,8 +4,8 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(ALLOCATION_SIZE);
-    free(p + 1);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p + 1);
 
     NOT_CAUGHT();
 

--- a/bench/security/invalid_free_unaligned_multiple.c
+++ b/bench/security/invalid_free_unaligned_multiple.c
@@ -4,8 +4,8 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(ALLOCATION_SIZE);
-    free(p + 8);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p + 8);
 
     NOT_CAUGHT();
 

--- a/bench/security/malloc_reuse.c
+++ b/bench/security/malloc_reuse.c
@@ -7,11 +7,11 @@
  * allocations. */
 
 int main(void) {
-    void *p = malloc(ALLOCATION_SIZE);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
     void *q = p;
-    free(p);
+    free_noinline(p);
 
-    p = malloc(ALLOCATION_SIZE);
+    p = malloc_noinline(ALLOCATION_SIZE);
 
     if (p == q)
     {

--- a/bench/security/malloc_reuse_downsize.c
+++ b/bench/security/malloc_reuse_downsize.c
@@ -7,11 +7,11 @@
  * an allocation and a smaller one. */
 
 int main(void) {
-    void *p = malloc(ALLOCATION_SIZE);
+    void *p = malloc_noinline(ALLOCATION_SIZE);
     void *q = p;
-    free(p);
+    free_noinline(p);
 
-    p = malloc(ALLOCATION_SIZE / 2);
+    p = malloc_noinline(ALLOCATION_SIZE / 2);
 
     if (p == q)
     {

--- a/bench/security/one_byte_memcpy_overflow.c
+++ b/bench/security/one_byte_memcpy_overflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE + 1] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/one_byte_memcpy_underflow.c
+++ b/bench/security/one_byte_memcpy_underflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p - 1, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/one_byte_overflow.c
+++ b/bench/security/one_byte_overflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[ALLOCATION_SIZE] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/one_byte_underflow.c
+++ b/bench/security/one_byte_underflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[-1] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/one_mbyte_memcpy_overflow.c
+++ b/bench/security/one_mbyte_memcpy_overflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE + 1024 * 1024] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/one_mbyte_memcpy_underflow.c
+++ b/bench/security/one_mbyte_memcpy_underflow.c
@@ -7,7 +7,7 @@
 
 int main(void) {
     const char c[ALLOCATION_SIZE] = {0};
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memcpy_noinline(p - 1024 * 1024, c, sizeof(c));
 
     NOT_CAUGHT();

--- a/bench/security/one_mbyte_overflow.c
+++ b/bench/security/one_mbyte_overflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[ALLOCATION_SIZE - 1 + (1024 * 1024)] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/one_mbyte_underflow.c
+++ b/bench/security/one_mbyte_underflow.c
@@ -4,9 +4,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     p[-(1024 * 1024)] ^= 'A'; // XOR is used to avoid the test having a 1/256 chance to fail
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/read_zero_size.c
+++ b/bench/security/read_zero_size.c
@@ -4,7 +4,7 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(0);
+    char *p = malloc_noinline(0);
     if (!p) {
         return 1;
     }

--- a/bench/security/read_zero_size_free.c
+++ b/bench/security/read_zero_size_free.c
@@ -4,12 +4,12 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(0);
+    char *p = malloc_noinline(0);
     if (!p) {
         return 1;
     }
     putchar(*p);
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/realloc_reuse.c
+++ b/bench/security/realloc_reuse.c
@@ -4,7 +4,7 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(8);
+    char *p = malloc_noinline(8);
     char *q = p;
     realloc(p, 1024);
 

--- a/bench/security/write_after_free.c
+++ b/bench/security/write_after_free.c
@@ -5,8 +5,8 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
-    free(p);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
     memset(p, 'A', ALLOCATION_SIZE);
 
     NOT_CAUGHT();

--- a/bench/security/write_after_free_reuse.c
+++ b/bench/security/write_after_free_reuse.c
@@ -5,12 +5,12 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
-    free(p);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
+    free_noinline(p);
     memset(p, 'A', ALLOCATION_SIZE);
 
     for (size_t i=0; i< 1024 * 256; i++)
-        free(malloc(ALLOCATION_SIZE));
+        free_noinline(malloc_noinline(ALLOCATION_SIZE));
 
     NOT_CAUGHT();
 

--- a/bench/security/write_zero_size.c
+++ b/bench/security/write_zero_size.c
@@ -4,7 +4,7 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(0);
+    char *p = malloc_noinline(0);
     if (!p) {
         return 1;
     }

--- a/bench/security/write_zero_size_free.c
+++ b/bench/security/write_zero_size_free.c
@@ -4,12 +4,12 @@
 #include "common.h"
 
 int main() {
-    char *p = malloc(0);
+    char *p = malloc_noinline(0);
     if (!p) {
         return 1;
     }
     *p = 'A';
-    free(p);
+    free_noinline(p);
 
     NOT_CAUGHT();
 

--- a/bench/security/zero_after_free.c
+++ b/bench/security/zero_after_free.c
@@ -5,9 +5,9 @@
 #include "common.h"
 
 int main(void) {
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     memset(p, 'A', ALLOCATION_SIZE);
-    free(p);
+    free_noinline(p);
 
     for (int i=0; i< ALLOCATION_SIZE; i++) {
         if (p[i] != 0) {

--- a/bench/security/zero_on_malloc.c
+++ b/bench/security/zero_on_malloc.c
@@ -11,16 +11,16 @@ int main(void) {
     // Do this incase the allocator randomizes new chunks
     char *allocations[ITERATIONS] = { 0 };
     for (int i = 0; i < ITERATIONS; i++) {
-        char *chunk = malloc(ALLOCATION_SIZE);
+        char *chunk = malloc_noinline(ALLOCATION_SIZE);
         memset(chunk, 'A', ALLOCATION_SIZE);
         allocations[i] = chunk;
     }
 
     for (int i = 0; i < ITERATIONS; i++) {
-        free(allocations[i]);
+        free_noinline(allocations[i]);
     }
 
-    char *p = malloc(ALLOCATION_SIZE);
+    char *p = malloc_noinline(ALLOCATION_SIZE);
     for (int i=0; i< ALLOCATION_SIZE; i++) {
         if (p[i] != 0) {
             NOT_CAUGHT();


### PR DESCRIPTION
I found that the compiler was applying knowledge of malloc and free, and optimising many of the security programs that are inherently UB into something else. By preventing the inlining these optimisations no longer occur.