### PR TITLE
Add an option to provide an external file of allocators.

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -265,6 +265,18 @@ function tests_run_add_remove { # <test> <add?>
   fi
 }
 
+function process_external { # file
+  REGEXP="^([^ ]+) +(.*)$"
+
+  while read -r ; do
+    echo $REPLY
+    if [[ $REPLY =~ $REGEXP ]]; then
+      alloc_lib_add ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}
+      alloc_run_add ${BASH_REMATCH[1]}
+    fi
+  done < $1
+}
+
 if test "$darwin" = "1"; then
   # remove tests that don't run on darwin
   tests_exclude="$tests_exclude $tests_exclude_macos"
@@ -331,6 +343,8 @@ while : ; do
         spec=*)
             test_run_add "spec"
             run_spec_bench="$flag_arg";;
+        --external=*)
+            process_external "$flag_arg";;
         -j=*|--procs=*)
             procs="$flag_arg";;
         -r=*)
@@ -351,6 +365,7 @@ while : ; do
             echo "  -r=<n>                       number of repeats of the full suite (=$repeats)"
             echo "  -n=<n>                       number of repeats of each individual test (=$test_repeats)"
             echo "  -s=<n>, --sleep=<n>          seconds of sleep between each test (=$sleep)"
+            echo "  --external=<file>            read external allocators from <file>, one per line, in the format <name> <path>"
             echo ""
             echo "  allt                         run all tests"
             echo "  alla                         run all allocators"

--- a/bench.sh
+++ b/bench.sh
@@ -268,13 +268,13 @@ function tests_run_add_remove { # <test> <add?>
 function read_external_allocators_from_file { # file
   REGEXP="^([^ ]+) +(.+)$"
 
-  while read -r ; do
-    if [[ $REPLY =~ $REGEXP ]]; then
-      echo Adding external allocator: $REPLY
+  while read -r LINE; do
+    if [[ $LINE =~ $REGEXP ]]; then
+      echo Adding external allocator: $LINE
       alloc_lib_add ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}
       alloc_run_add ${BASH_REMATCH[1]}
     else
-      echo "Invalid line in external allocators file: $REPLY"
+      echo "Invalid line in external allocators file: $LINE"
     fi
   done < $1
 }

--- a/bench.sh
+++ b/bench.sh
@@ -265,14 +265,16 @@ function tests_run_add_remove { # <test> <add?>
   fi
 }
 
-function process_external { # file
-  REGEXP="^([^ ]+) +(.*)$"
+function read_external_allocators_from_file { # file
+  REGEXP="^([^ ]+) +(.+)$"
 
   while read -r ; do
-    echo $REPLY
     if [[ $REPLY =~ $REGEXP ]]; then
+      echo Adding external allocator: $REPLY
       alloc_lib_add ${BASH_REMATCH[1]} ${BASH_REMATCH[2]}
       alloc_run_add ${BASH_REMATCH[1]}
+    else
+      echo "Invalid line in external allocators file: $REPLY"
     fi
   done < $1
 }
@@ -344,7 +346,7 @@ while : ; do
             test_run_add "spec"
             run_spec_bench="$flag_arg";;
         --external=*)
-            process_external "$flag_arg";;
+            read_external_allocators_from_file "$flag_arg";;
         -j=*|--procs=*)
             procs="$flag_arg";;
         -r=*)


### PR DESCRIPTION
This is useful for testing various versions of an allocator at once without having to modify the bench.sh.

E.g.

test.allocs:
```
sn     /home/mjp41/snmalloc/build/libsnmallocshim.so
sn-m1  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-1.so
sn-m2  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-2.so
sn-m3  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-3.so
sn-m4  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-4.so
sn-m5  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-5.so
sn-m6  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-6.so
sn-m7  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-7.so
sn-m8  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-8.so
sn-m9  /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-9.so
sn-m10 /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-10.so
sn-m11 /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-11.so
sn-m12 /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-12.so
sn-m13 /home/mjp41/snmalloc/build/libsnmallocshim-mitigations-13.so
```

and then the command line

```
  ../../bench.sh --external=test.allocs cfrac
```

will run cfrac on all 14 specified allocators.