### PR TITLE
Add support for PartitionAlloc

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -26,9 +26,10 @@ jobs:
         # lf: crashes redis server
         # lt: return type 'struct mallinfo' is incomplete
         # mesh/nomesh: infinite loop?
+        # pa: can't setup depot_tools and goma
         # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
         # tcg: [...] specifies less restrictive attribute than its target [...]
-        run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-gd no-fg no-lf no-lt no-tcg
+        run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-pa no-gd no-fg no-lf no-lt no-tcg
       - name: Run everything.
         run: |
           cd out/bench

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ for the versions:
 - **mi**: The [_mimalloc_](https://github.com/microsoft/mimalloc) allocator.
   We can also test the debug version as **dmi** (this can be used to check for
   any bugs in the benchmarks), and the secure version as **smi**.
+- **pa**: The [_PartitionAlloc_](https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git/+/refs/heads/main/PartitionAlloc.md) allocator used in Chromium.
 - **rp**: The [_rpmalloc_](https://github.com/mjansson/rpmalloc) allocator uses
   16-byte aligned allocations and is developed by [Mattias
   Jansson](https://twitter.com/maniccoder) at Epic Games, used for example

--- a/bench.sh
+++ b/bench.sh
@@ -6,8 +6,8 @@
 # Allocators and tests
 # --------------------------------------------------------------------
 
-readonly alloc_all="sys dh ff fg gd hd hm hml iso je lp lt mi mi-sec mng mesh nomesh rp sc scudo sg sm sn sn-sec tbb tc tcg dmi xmi xsmi xdmi"
-readonly alloc_secure="dh ff gd hm hml iso mi-sec mng scudo sg sn-sec sg"
+readonly alloc_all="sys dh ff fg gd hd hm hml iso je lp lt mi mi-sec mng mesh nomesh pa rp sc scudo sg sm sn sn-sec tbb tc tcg dmi xmi xsmi xdmi"
+readonly alloc_secure="dh ff gd hm hml iso mi-sec mng pa scudo sg sn-sec sg"
 alloc_run=""           # allocators to run (expanded by command line options)
 alloc_installed="sys"  # later expanded to include all installed allocators
 alloc_libs="sys="      # mapping from allocator to its .so as "<allocator>=<sofile> ..."
@@ -112,6 +112,7 @@ alloc_lib_add "lt"     "$localdevdir/lt/gnu.make.lib/libltalloc$extso"
 alloc_lib_add "mesh"   "$localdevdir/mesh/build/lib/libmesh$extso"
 alloc_lib_add "mng"    "$localdevdir/mng/libmallocng$extso"
 alloc_lib_add "nomesh" "$localdevdir/nomesh/build/lib/libmesh$extso"
+alloc_lib_add "pa"     "$localdevdir/pa/partition_alloc_builder/out/Default/libpalib$extso"
 alloc_lib_add "rp"     "$lib_rp"
 alloc_lib_add "sc"     "$localdevdir/sc/out/Release/lib.target/libscalloc$extso"
 alloc_lib_add "scudo"  "$localdevdir/scudo/compiler-rt/lib/scudo/standalone/libscudo$extso"
@@ -392,6 +393,7 @@ while : ; do
             echo "  mi-sec                       use secure version of mimalloc"
             echo "  mng                          use mallocng"
             echo "  nomesh                       use mesh with meshing disabled"
+            echo "  pa                           use PartitionAlloc"
             echo "  rp                           use rpmalloc"
             echo "  sc                           use scalloc"
             echo "  scudo                        use scudo"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -507,8 +507,8 @@ if test "$setup_pa" = "1"; then
   checkout pa $version_pa https://github.com/1c3t3a/partition_alloc_builder.git
 
   # Setup depot_tools for building
-  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  export PATH="$PATH:${pwd}/depot_tools"
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git --depth=1
+  export PATH="$PATH:$PWD/depot_tools"
 
   # Fetch sources - this relies on a standalone build of PA
   gclient config https://github.com/1c3t3a/partition_alloc_builder.git

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -47,6 +47,7 @@ readonly version_mesh=master # ~unmaintained since 2021
 readonly version_mi=v1.7.7
 readonly version_mng=master  # ~unmaintained
 readonly version_nomesh=$version_mesh
+readonly version_pa=main
 readonly version_rp=f4732ee  # https://github.com/mjansson/rpmalloc/issues/293#issuecomment-1336502654
 readonly version_sc=master   # unmaintained since 2016
 readonly version_scudo=main
@@ -79,6 +80,7 @@ setup_mesh=0
 setup_mi=0
 setup_mng=0
 setup_nomesh=0
+setup_pa=0
 setup_rp=0
 setup_sc=0
 setup_scudo=0
@@ -123,6 +125,7 @@ while : ; do
         setup_je=$flag_arg
         setup_lp=$flag_arg
         setup_mi=$flag_arg
+        setup_pa=$flag_arg
         setup_sn=$flag_arg
         setup_sg=$flag_arg
         setup_tbb=$flag_arg
@@ -187,6 +190,8 @@ while : ; do
         setup_mi=$flag_arg;;
     nomesh)
         setup_nomesh=$flag_arg;;
+    pa)
+        setup_pa=$flag_arg;;
     packages)
         setup_packages=$flag_arg;;
     redis)
@@ -238,6 +243,7 @@ while : ; do
         echo "  mi                           setup mimalloc ($version_mi)"
         echo "  mng                          setup mallocng ($version_mng)"
         echo "  nomesh                       setup mesh allocator w/o meshing ($version_mesh)"
+        echo "  pa                           setup PartitionAlloc ($version_pa)"
         echo "  rp                           setup rpmalloc ($version_rp)"
         echo "  sc                           setup scalloc ($version_sc)"
         echo "  scudo                        setup scudo ($version_scudo)"
@@ -494,6 +500,23 @@ fi
 if test "$setup_lt" = "1"; then
   checkout lt $version_lt https://github.com/r-lyeh-archived/ltalloc
   make -j $procs -C gnu.make.lib
+  popd
+fi
+
+if test "$setup_pa" = "1"; then
+  checkout pa $version_pa https://github.com/1c3t3a/partition_alloc_builder.git
+
+  # Setup depot_tools for building
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  export PATH="$PATH:${pwd}/depot_tools"
+
+  # Fetch sources - this relies on a standalone build of PA
+  gclient config https://github.com/1c3t3a/partition_alloc_builder.git
+  gclient sync
+  cd partition_alloc_builder
+
+  gn gen out/Default
+  autoninja -C out/Default
   popd
 fi
 

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -403,7 +403,7 @@ if test "$setup_packages" = "1"; then
     # no 'apt update' equivalent needed on Fedora
     dnfinstall "gcc-c++ clang lld llvm-devel unzip dos2unix bc gmp-devel wget gawk \
       cmake python3 ruby ninja-build libtool autoconf git patch time sed \
-      ghostscript libatomic which gflags-devel"
+      ghostscript libatomic which gflags-devel xz"
     dnfinstallbazel
   elif grep -q -e 'ID=debian' -e 'ID=ubuntu' /etc/os-release 2>/dev/null; then
     echo "updating package database... ($SUDO apt update)"


### PR DESCRIPTION
This change adds support for PartitionAlloc, the memory allocator used in chromium. Normally the allocator is build in-tree, but this pulls in a [standalone version](https://github.com/1c3t3a/partition_alloc_builder). The standalone version added here should be updated as soon as the official repository of PartitionAlloc (https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator) supports standalone builds. This closes #184.