### PR TITLE
Fix the mismatch version of rocksdb in build.sh

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -29,7 +29,7 @@ readonly tests_exclude_macos="sh6bench sh8bench redis"
 # --------------------------------------------------------------------
 
 readonly version_redis=6.2.7
-readonly version_rocksdb=7.3.1
+readonly version_rocksdb=8.1.1
 
 # --------------------------------------------------------------------
 # Environment


### PR DESCRIPTION
I noticed that the version of rocksdb in build.sh does not match the one in build-bench-env.sh, so I fixed it.
Now the version of rocksdb is 8.1.1