### PR TITLE
Add compiling linux as a benchmark

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -14,7 +14,7 @@ alloc_libs="sys="      # mapping from allocator to its .so as "<allocator>=<sofi
 
 readonly tests_all1="cfrac espresso barnes redis lean larson-sized mstress rptest gs lua"
 readonly tests_all2="alloc-test sh6bench sh8bench xmalloc-test cscratch glibc-simple glibc-thread rocksdb"
-readonly tests_all3="larson lean-mathlib malloc-large mleak rbstress cthrash"
+readonly tests_all3="larson lean-mathlib linux malloc-large mleak rbstress cthrash"
 readonly tests_all4="z3 spec spec-bench security"
 
 readonly tests_all="$tests_all1 $tests_all2 $tests_all3 $tests_all4"
@@ -30,6 +30,7 @@ readonly tests_exclude_macos="sh6bench sh8bench redis"
 
 readonly version_redis=6.2.7
 readonly version_rocksdb=8.1.1
+readonly version_linux=6.5.1
 
 # --------------------------------------------------------------------
 # Environment
@@ -161,6 +162,7 @@ readonly leanmldir="$leandir/../mathlib"
 readonly redis_dir="$localdevdir/redis-$version_redis/src"
 readonly pdfdoc="$localdevdir/large.pdf" 
 readonly rocksdb_dir="$localdevdir/rocksdb-$version_rocksdb"
+readonly linux_dir="$localdevdir/linux-$version_linux"
 
 readonly spec_dir="$localdevdir/../../spec2017"
 readonly spec_base="base"
@@ -536,6 +538,11 @@ function run_test_env_cmd { # <test name> <allocator name> <environment args> <c
       outfile="$1-$2-out.txt";;
     barnes)
       infile="$benchdir/barnes/input";;
+    linux)
+      pushd "$linux_dir"
+      make distclean
+      make allnoconfig
+      popd;;
   esac
   case "$1" in
     redis*)
@@ -669,6 +676,10 @@ function run_test {  # <test>
       pushd "$leanmldir"
       run_test_cmd "mathlib" "$leandir/bin/leanpkg build"
       popd;;
+    linux)
+	  pushd "$linux_dir"
+	  run_test_cmd "linux" "make -j $procs"
+	  popd;;
     redis)
       # https://redis.io/docs/reference/optimization/benchmarks/
       redis_tail="1"

--- a/bench.sh
+++ b/bench.sh
@@ -539,9 +539,11 @@ function run_test_env_cmd { # <test name> <allocator name> <environment args> <c
     barnes)
       infile="$benchdir/barnes/input";;
     linux)
+      builddir="/tmp/linux_build"
       pushd "$linux_dir"
-      make distclean
-      make allnoconfig
+      mkdir -p $builddir
+      make O=$builddir distclean
+      make O=$builddir allnoconfig
       popd;;
   esac
   case "$1" in
@@ -677,9 +679,10 @@ function run_test {  # <test>
       run_test_cmd "mathlib" "$leandir/bin/leanpkg build"
       popd;;
     linux)
-	  pushd "$linux_dir"
-	  run_test_cmd "linux" "make -j $procs"
-	  popd;;
+      builddir="/tmp/linux_build"
+      pushd "$linux_dir"
+      run_test_cmd "linux" "make O=$builddir -j $procs"
+      popd;;
     redis)
       # https://redis.io/docs/reference/optimization/benchmarks/
       redis_tail="1"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -202,7 +202,7 @@ while : ; do
     rocksdb)
         setup_rocksdb=$flag_arg;;
     linux)
-		setup_linux=$flag_arg;;
+        setup_linux=$flag_arg;;
     rp)
         setup_rp=$flag_arg;;
     sc)

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -63,6 +63,7 @@ readonly version_redis=6.2.7
 readonly version_lean=v3.4.2
 readonly version_rocksdb=8.1.1
 readonly version_lua=v5.4.4
+readonly version_linux=6.5.1
 
 # allocators
 setup_dh=0
@@ -96,6 +97,7 @@ setup_bench=0
 setup_lean=0
 setup_redis=0
 setup_rocksdb=0
+setup_linux=0
 
 # various
 setup_packages=0
@@ -153,6 +155,7 @@ while : ; do
         setup_lean=$flag_arg
         setup_redis=$flag_arg
         setup_rocksdb=$flag_arg
+        setup_linux=$flag_arg
         setup_bench=$flag_arg
         setup_packages=$flag_arg
         ;;
@@ -198,6 +201,8 @@ while : ; do
         setup_redis=$flag_arg;;
     rocksdb)
         setup_rocksdb=$flag_arg;;
+    linux)
+		setup_linux=$flag_arg;;
     rp)
         setup_rp=$flag_arg;;
     sc)
@@ -259,6 +264,7 @@ while : ; do
         echo "  packages                     setup required packages"
         echo "  redis                        setup redis benchmark"
         echo "  rocksdb                      setup rocksdb benchmark"
+        echo "  linux                        setup linux benchmark"
         echo ""
         echo "Prefix an option with 'no-' to disable an option"
         exit 0;;
@@ -796,6 +802,18 @@ if test "$setup_bench" = "1"; then
   cd ../..
 fi
 
+if test "$setup_linux" = "1"; then
+  phase "fetch linux"
+  pushd "$devdir"
+  if test -d "linux-$version_linux"; then
+    echo "$devdir/linux-$version_linux already exists; no need to download it"
+  else
+    wget --no-verbose "https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-$version_linux.tar.xz"
+    tar xf "linux-$version_linux.tar.xz"
+    rm "./linux-$version_linux.tar.xz"
+  fi
+  popd
+fi
 
 curdir=`pwd`
 


### PR DESCRIPTION
This adds compiling linux as a benchmark.
I opted for the latest stable version as of right now. It's building a 'allnoconfig' to not run too long. It's building in RAM to reduce file I/O overhead. I have no idea how to realize that on platforms other than *nix, though.

Comments and feedback welcome :)