### PR TITLE
Fix libpas build with clang16

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -492,6 +492,9 @@ if test "$setup_lp" = "1"; then
     ORIG="_orig"
   fi
   sed -i $ORIG '/Werror/d' CMakeLists.txt
+  # Fix compilation with recent compilers
+  # (at least clang16 that enforces -Wimplicit-function-declaration)
+  sed -i $ORIG 's/extra_cmake_options=""/extra_cmake_options="-D_GNU_SOURCE=1"/' build.sh
   # Remove once/if https://github.com/WebKit/WebKit/pull/1219 is merged
   sed -i $ORIG 's/cmake --build $build_dir --parallel/cmake --build $build_dir --target pas_lib --parallel/' build.sh
   if test "$darwin" = "1"; then


### PR DESCRIPTION
Using clang16 without this patch, building the `libpas` allocator results in the following error:
```
/home/atn/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    getname_result = pthread_getname_np(thread, thread_name, sizeof(thread_name));
```
The `-Wimplicit-function-declaration` warning now defaults to an error in C99, C11 and C17 (https://github.com/llvm/llvm-project/blob/release/16.x/clang/docs/ReleaseNotes.rst#potentially-breaking-changes).
As this function is a nonstandard GNU extension, defining the `_GNU_SOURCE` symbol fixes the implicit declaration.
This fix likely isn't the best way, I found https://github.com/WebKit/WebKit/pull/1309/commits which is a proper upstream fix, but I don't get why this was (afaik) not merged.