### PR TITLE
Fix lockfree-malloc description + bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ for the versions:
   allocator by [Jason Evans](https://github.com/jasone),
   now developed at Facebook
   and widely used in practice, for example in FreeBSD and Firefox.
+- **lf**: The [_lockfree-malloc_](https://github.com/Begun/lockfree-malloc) allocator,
+  multi-thread scalability-focused.
 - **lp**: The [_libpas_](https://github.com/WebKit/WebKit/tree/main/Source/bmalloc/libpas)
   allocator, used by [WebKit](https://webkit.org).
 - **mng**: [musl](https://musl.libc.org)'s memory allocator.

--- a/bench.sh
+++ b/bench.sh
@@ -6,7 +6,7 @@
 # Allocators and tests
 # --------------------------------------------------------------------
 
-readonly alloc_all="sys dh ff fg gd hd hm hml iso je lp lt mi mi-sec mi2 mi2-sec mng mesh nomesh pa rp sc scudo sg sm sn sn-sec tbb tc tcg mi-dbg mi2-dbg xmi xsmi xmi-dbg"
+readonly alloc_all="sys dh ff fg gd hd hm hml iso je lf lp lt mi mi-sec mi2 mi2-sec mng mesh nomesh pa rp sc scudo sg sm sn sn-sec tbb tc tcg mi-dbg mi2-dbg xmi xsmi xmi-dbg"
 readonly alloc_secure="dh ff gd hm hml iso mi-sec mi2-sec mng pa scudo sg sn-sec sg"
 alloc_run=""           # allocators to run (expanded by command line options)
 alloc_installed="sys"  # later expanded to include all installed allocators


### PR DESCRIPTION
lf was not benched when using alla shortcut to run all allocators