### PR TITLE
Fix rpmalloc build with clang-16

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -615,6 +615,9 @@ if test "$setup_rp" = "1"; then
   else
     python3 configure.py
   fi
+  # fix build using clang-16
+  # see https://github.com/mjansson/rpmalloc/issues/316
+  sed -i 's/-Werror//' build.ninja
   ninja
   popd
 fi


### PR DESCRIPTION
In the rpmalloc ad-hoc build script, the produced Ninja build file contains the -Werror flag, which leads to a build failure, as clang-16 emits unsafe-buffer-usage and embedded-directive warnings, see https://github.com/mjansson/rpmalloc/issues/316.