### PR TITLE
Update README to include description of missing supported allocators

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ for the versions:
   multi-thread scalability-focused.
 - **lp**: The [_libpas_](https://github.com/WebKit/WebKit/tree/main/Source/bmalloc/libpas)
   allocator, used by [WebKit](https://webkit.org).
+- **lt**: The [_ltalloc_](https://github.com/r-lyeh-archived/ltalloc) allocator,
+  a multi-threaded memory allocator based on free lists best suited for many small allocations.
 - **mesh**: The [_mesh_](https://github.com/plasma-umass/mesh) allocator, a
   memory allocator that automatically reduces the memory footprint of C/C++
   applications. Also tested as **nomesh** with the meshing feature disabled.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ for the versions:
   OS X.
 - **ff**: [ffmalloc](https://github.com/bwickman97/ffmalloc), from the Usenix
   Security 21 [paper](https://www.usenix.org/conference/usenixsecurity21/presentation/wickman)
+- **fg**: The [_FreeGuard_](https://github.com/UTSASRG/FreeGuard) allocator, from
+  the CCS 17 [paper](https://dl.acm.org/doi/10.1145/3133956.3133957)
 - **gd**: The [_Guarder_](https://github.com/UTSASRG/Guarder) allocator
   is a tunable secure allocator by the UTSA.
 - **hd**: The [_Hoard_](https://github.com/emeryberger/Hoard) allocator by
@@ -91,13 +93,13 @@ for the versions:
   multi-thread scalability-focused.
 - **lp**: The [_libpas_](https://github.com/WebKit/WebKit/tree/main/Source/bmalloc/libpas)
   allocator, used by [WebKit](https://webkit.org).
-- **mng**: [musl](https://musl.libc.org)'s memory allocator.
 - **mesh**: The [_mesh_](https://github.com/plasma-umass/mesh) allocator, a
   memory allocator that automatically reduces the memory footprint of C/C++
   applications. Also tested as **nomesh** with the meshing feature disabled.
 - **mi**: The [_mimalloc_](https://github.com/microsoft/mimalloc) allocator.
   We can also test the debug version as **dmi** (this can be used to check for
   any bugs in the benchmarks), and the secure version as **smi**.
+- **mng**: [musl](https://musl.libc.org)'s memory allocator.
 - **pa**: The [_PartitionAlloc_](https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git/+/refs/heads/main/PartitionAlloc.md) allocator used in Chromium.
 - **rp**: The [_rpmalloc_](https://github.com/mjansson/rpmalloc) allocator uses
   16-byte aligned allocations and is developed by [Mattias


### PR DESCRIPTION
I just realized that the top-level README was missing mentions of FreeGuard (fg) and ltmalloc (lt), which are currently supported by the benchmarking suite.
This PR adds mentions of them both to the README, and also reorganizes the list to be in alphabetical order, matching the build script (mng was moved after mi).