### PR TITLE
add some additional installation dependencies for Ubuntu/Debian

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -417,7 +417,7 @@ if test "$setup_packages" = "1"; then
     aptinstall "g++ clang lld llvm-dev unzip dos2unix linuxinfo bc libgmp-dev wget \
       cmake python3 ruby ninja-build libtool autoconf sed ghostscript time \
       curl automake libatomic1 libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev \
-      liblz4-dev libzstd-dev libreadline-dev"
+      liblz4-dev libzstd-dev libreadline-dev pkg-config gawk util-linux"
     aptinstallbazel
   elif grep -q -e 'ID=alpine' /etc/os-release 2>/dev/null; then
     echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories


### PR DESCRIPTION
pkg-config in building pa with ninja
gawk in building pa with ninja which was mentioned in https://github.com/daanx/mimalloc-bench/issues/202#issuecomment-1970018563
`column` in util-linux to support `cat $devdir/version_*.txt 2>/dev/null | tee $devdir/versions.txt | column -t || true `