### PR TITLE
Fix sh8bench build with gcc-14

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -40,7 +40,7 @@ PREPEND(barnes_sources barnes/ ${barnes_sources})
 # turn off warnings..
 message(STATUS "${CMAKE_C_COMPILER_ID}")
 if(CMAKE_C_COMPILER_ID MATCHES "AppleClang|Clang|GNU")
-  set(FLAGS " -w -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion")
+  set(FLAGS " -w -Wno-implicit-function-declaration -Wno-implicit-int -Wno-int-conversion -Wno-return-mismatch -Wno-incompatible-pointer-types")
   string(APPEND CMAKE_C_FLAGS ${FLAGS})
   string(APPEND CMAKE_CXX_FLAGS ${FLAGS})
 endif()


### PR DESCRIPTION
GCC 14 adds new warnings treated as errors, see [1, 2]. As part of these, `-Wreturn-mismatch` `-Wincompatible-pointer-types` lead to a build error when compiling the `sh8bench` `bench/sh8bench/sh8bench-new.c` file.
Thus, this adds corresponding flags to only treat these warnings as warnings.

[1] https://gcc.gnu.org/gcc-14/porting_to.html
[2] https://wiki.gentoo.org/wiki/Modern_C_porting