### PR TITLE
Fix UB in pops.c

### DIFF
--- a/bench/cfrac/pops.c
+++ b/bench/cfrac/pops.c
@@ -91,10 +91,11 @@ precision palloc(size)
    register posit size;
 {
    register precision w;
-   register cacheType *kludge = pcache + size;	/* for shitty compilers */
+   register cacheType *kludge;  /* for shitty compilers */
 
 #if !(defined(NOMEMOPT) || defined(BWGC))
-   if (size < CACHESIZE && (w = kludge->next) != pUndef) {
+   if (size < CACHESIZE && (kludge = pcache + size) &&
+       (w = kludge->next) != pUndef) {
       kludge->next = ((cacheType *) w)->next;
       --kludge->count;
    } else {
@@ -135,9 +136,9 @@ int pfree(u)
 
    size = u->alloc;
 
-   kludge = pcache + size;
 #if !(defined(NOMEMOPT) || defined(BWGC))
-   if (size < CACHESIZE && kludge->count < CACHELIMIT) {
+   if (size < CACHESIZE && (kludge = pcache + size) &&
+       kludge->count < CACHELIMIT) {
       ((cacheType *) u)->next = kludge->next;
       kludge->next = u;
       kludge->count++;


### PR DESCRIPTION
It is undefined behaviour to construct a pointer that is out-of-bounds, not just to use it.

C23 standard says: If the pointer operand and the result do not point 
to elements of the same array object or one past the last element of the array object,
the behavior is undefined.