### PR TITLE
fix: Update DieHard build to use CMake and correct library path

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -97,7 +97,7 @@ readonly lib_tbb="$localdevdir/tbb/bench_release/libtbbmalloc_proxy$extso"
 readonly lib_tbb_dir="$(dirname $lib_tbb)"
 
 
-alloc_lib_add "dh"     "$localdevdir/dh/src/libdieharder$extso"
+alloc_lib_add "dh"     "$localdevdir/dh/src/build/libdieharder$extso"
 alloc_lib_add "ff"     "$localdevdir/ff/libffmallocnpmt$extso"
 alloc_lib_add "fg"     "$localdevdir/fg/libfreeguard$extso"
 alloc_lib_add "gd"     "$localdevdir/gd/libguarder$extso"

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -566,10 +566,8 @@ if test "$setup_dh" = "1"; then
   # remove all the historical useless junk
   rm -rf ./benchmarks/ ./src/archipelago/ ./src/build/ ./src/exterminator/ ./src/local/ ./src/original-diehard/ ./src/replicated/ ./docs
   cd src
-  mkdir -p build
-  cd build
-  cmake ..
-  make
+  cmake -S . -B build
+  cmake --build build -j `nproc`
   cd ../..
   popd
 fi

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -37,7 +37,7 @@ rebuild=0
 all=0
 
 # allocator versions
-readonly version_dh=640949fe0128d9c7013677c8c332698d5c2cefc2   # last unmaintained version, see https://github.com/daanx/mimalloc-bench/issues/222 for the up-to-date one
+readonly version_dh=master
 readonly version_ff=master   # ~unmaintained since 2021
 readonly version_fg=master   # ~unmaintained since 2018
 readonly version_gd=master   # ~unmaintained since 2021
@@ -565,11 +565,12 @@ if test "$setup_dh" = "1"; then
   checkout dh $version_dh https://github.com/emeryberger/DieHard
   # remove all the historical useless junk
   rm -rf ./benchmarks/ ./src/archipelago/ ./src/build/ ./src/exterminator/ ./src/local/ ./src/original-diehard/ ./src/replicated/ ./docs
-  if test "$darwin" = "1"; then
-    TARGET=libdieharder make -C src macos
-  else
-    TARGET=libdieharder make -C src linux-gcc-64
-  fi
+  cd src
+  mkdir -p build
+  cd build
+  cmake ..
+  make
+  cd ../..
   popd
 fi
 


### PR DESCRIPTION
fix: Update DieHard build to use CMake and correct library path

- Replace Makefile-based build with CMake (matches upstream)
- Fix library path from src/libdieharder.so to src/build/libdieharder.so
- Remove directory stack manipulation to fix popd error

Fixes #222


self test:
```
yxc@yxc-MS-7B89:~/code/2505/mimalloc-bench_dev$ ./build-bench-env.sh bench dh

building with 16 threads
--------------------------------------------
--------------------------------------------
build dh: version master
--------------------------------------------
~/code/2505/mimalloc-bench_dev/extern ~/code/2505/mimalloc-bench_dev
Cloning into 'dh'...
remote: Enumerating objects: 3091, done.
remote: Counting objects: 100% (117/117), done.
remote: Compressing objects: 100% (87/87), done.
remote: Total 3091 (delta 60), reused 66 (delta 30), pack-reused 2974 (from 1)
Receiving objects: 100% (3091/3091), 38.56 MiB | 7.66 MiB/s, done.
Resolving deltas: 100% (1338/1338), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
[100%] Linking C executable espresso
[100%] Built target espresso


--------------------------------------------
installed allocators
--------------------------------------------

dh:   master,  975a067,   https://github.com/emeryberger/DieHard
lua:  v5.4.7,  1ab3208a,  https://github.com/lua/lua

--------------------------------------------
done in /home/yxc/code/2505/mimalloc-bench_dev
--------------------------------------------

run the cfrac benchmarks as:
> cd out/bench
> ../../bench.sh alla cfrac

to see all options use:
> ../../bench.sh help
yxc@yxc-MS-7B89:~/code/2505/mimalloc-bench_dev$ cd out/bench
yxc@yxc-MS-7B89:~/code/2505/mimalloc-bench_dev/out/bench$ ../../bench.sh alla cfrac
benchmarking on 16 cores.
use '-h' or '--help' for help on configuration options.

allocators:  sys dh
tests     :  cfrac
(excluded tests:  lean lean-mathlib)

---- 1: cfrac

run 1: cfrac sys: SYSMALLOC=1 ./cfrac 17545186520507317056371138836327483792789528
cfrac       sys   0:06.29 2900 6.28 0.00 0 424

run 1: cfrac dh: LD_PRELOAD=/home/yxc/code/2505/mimalloc-bench_dev/extern/dh/src/build/libdieharder.so ./cfrac 17545186520507317056371138836327483792789528
cfrac       dh    0:12.25 9496 12.24 0.00 0 1384

results written to: /home/yxc/code/2505/mimalloc-bench_dev/out/bench/benchres.csv

#------------------------------------------------------------------
# test    alloc   time  rss    user  sys  page-faults page-reclaims
cfrac       sys   06.29 2900 6.28 0.00 0 424
cfrac       dh    12.25 9496 12.24 0.00 0 1384

```