### PR TITLE
build: rocksdb: do not include TCMalloc

### DIFF
--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -768,7 +768,7 @@ if test "$setup_rocksdb" = "1"; then
   fi
 
   cd "rocksdb-$version_rocksdb"
-  DISABLE_WARNING_AS_ERROR=1 DISABLE_JEMALLOC=1 make db_bench -j $procs
+  DISABLE_WARNING_AS_ERROR=1 DISABLE_JEMALLOC=1 ROCKSDB_DISABLE_TCMALLOC=1 make db_bench -j $procs
   [ "$CI" ] && find . -name '*.o' -delete
   popd
 fi


### PR DESCRIPTION
I saw crahses on some allocators without this and code from TCMalloc linked into the benchmark - we clearly want to use the allocator provided by the environment, nothing built in