### PR TITLE
ignore artifacts generated by shbench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ bench/shbench/sh6bench.c
 bench/shbench/sh6bench-new.c
 bench/shbench/SH8BENCH.C
 bench/shbench/sh8bench-new.c
+bench/shbench/*.zip*
 *.zip


### PR DESCRIPTION
bench.zip.{1,2} were not match with the last line in .gitignore. To avoid ignoring future files that contain ".zip" somewhere in the middle, add a specific entry