### PR TITLE
Patch sh8bench

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 *.sln binary
 *.suo binary
 *.vcproj binary
-*.patch binary

--- a/bench/shbench/sh8bench.patch
+++ b/bench/shbench/sh8bench.patch
@@ -2,6 +2,10 @@
 < unsigned long ulIterations   =  100000;
 ---
 > unsigned long ulIterations   =  700000;
+180c180
+< void main(int argc, char *argv[])
+---
+> int main(int argc, char *argv[])
 194c194,203
 < 	
 ---


### PR DESCRIPTION
sh8bench's main function is of type void, which is undefined behavior in C. I've actually hit random and bogus non-zero exit statuses on my machine. Conform to the standard to fix this.