### PR TITLE
bench/security: add -fno-ipa-pure-const to compile options

### DIFF
--- a/bench/security/CMakeLists.txt
+++ b/bench/security/CMakeLists.txt
@@ -9,6 +9,7 @@ macro (add_security_test test_name test_file allocation_size)
     -fno-inline
     -fno-builtin-inline
     -fno-inline-small-functions 
+    -fno-ipa-pure-const
     -DALLOCATION_SIZE=${allocation_size})
 endmacro ()
 


### PR DESCRIPTION
this tells gcc not to mark functions as pure or const on its own, which would enable some optimisations that might undermine security tests. Fixes #207