### PR TITLE
bench/alloc-test: use the unix way for clock determination on AARCH64

### DIFF
--- a/bench/alloc-test/test_common.h
+++ b/bench/alloc-test/test_common.h
@@ -48,7 +48,7 @@
 #define NOINLINE      __declspec(noinline)
 #define FORCE_INLINE	__forceinline
 #elif __GNUC__
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(__aarch64__)
 #include <time.h>
 //#if defined(CLOCK_REALTIME) || defined(CLOCK_MONOTONIC)
 static inline uint64_t get_timestamp(void) {


### PR DESCRIPTION
Up to now, this was detected for Apple hardware, but there are other AARCH64 machines out there, too. While in the file, add a newline at the end as it is supposed to be there.