### PR TITLE
bench: update minimum CMake version

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(mimalloc-bench CXX C)
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
CMake 4.0 dropped support for versions older than 3.5 and errors out if trying to require less: [https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features](https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features). Set the minimum verison to 3.5 to avoid this.