### PR TITLE
Cache some of the build using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github
+Dockerfile
+README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .github
+.git
 Dockerfile
 README.md

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and run benchmarks in Docker
+      - name: Build benchmarks in Docker
         id: docker_build
         uses: docker/build-push-action@v4
         with:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build and run benchmarks in Docker
+      - name: Build allocator and run benchmarks in Docker
         id: docker_build
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -5,107 +5,158 @@ on:
   schedule:
     - cron: '0 0 * * 1'
 jobs:
-  build-all-alpine:
-    runs-on: ubuntu-latest
-    container:
-      image: alpine:latest
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - name: Install bash
-        run: apk add bash git
-      - name: Silence some git warnings
-        run: |
-          git config --global advice.detachedHead false
-          git config --global init.defaultBranch main
-      - name: Install and build all benchmarks and allocators
-        # dh: glibc-specific
-        # fg: Uses execinfo.h, which is a GNU extension
-        # gd: ?
-        # hd: glibc-specific
-        # lf: crashes redis server
-        # lt: return type 'struct mallinfo' is incomplete
-        # mesh/nomesh: infinite loop?
-        # pa: can't setup depot_tools and goma
-        # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
-        # tcg: [...] specifies less restrictive attribute than its target [...]
-        # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-        # rp: rpmalloc/rpmalloc.c:980:9: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
-        run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-pa no-gd no-fg no-lf no-lt no-tcg no-lp no-rp
-      - name: Run everything.
-        run: |
-          cd out/bench
-          ../../bench.sh alla allt
-  build-all-ubuntu:
+  build-base-with-docker:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Silence some git warnings
-        run: |
-          git config --global advice.detachedHead false
-          git config --global init.defaultBranch main
-      - name: Install and build all benchmarks and allocators
-        # fg: crashes on redis
-        # gd: infinite loop in the redis benchmark
-        # lt: breaks on sh8benchN
-        # lf: crashes redis server
-        # ff: crashes on modern ubuntu: https://github.com/bwickman97/ffmalloc/issues/5
-        # hoard: crashes on rocksdb
-        # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-        # sn: /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
-        # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-        # tcg: ERROR: Error computing the main repository mapping: protobuf@29.0 depends on rules_fuzzing@0.5.2 with compatibility level 0, but <root> depends on rules_fuzzing@0.5.1 with compatibility level 1 which is different
-        run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-lt no-lf no-hd no-pa no-sn no-lp no-tcg
-      - name: Run everything.
-        run: |
-          cd out/bench
-          ../../bench.sh alla allt
-  build-all-fedora:
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and run benchmarks in Docker
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: bench
+          target: bench-env
+          build-args: |
+            platform=ubuntu
+            platform_version=24.04
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-and-benchmark-allocator:
     runs-on: ubuntu-latest
-    container:
-      image: fedora:latest
+    needs: build-base-with-docker
+    strategy:
+      matrix:
+        allocator: [mi, sn]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Install git
-        run: sudo dnf -y --quiet --nodocs install git
-      - name: Silence some git warnings
-        run: |
-          git config --global advice.detachedHead false
-          git config --global init.defaultBranch main
-      - name: Install and build all benchmarks and allocators
-        # gd: infinite loop in the redis benchmark
-        # mesh/nomesh: error: '__malloc_hook' was not declared in this scope;
-        # mi: error: '__malloc_hook' was not declared in this scope;
-        # rp: mixing declarations and code is incompatible with standards before C99
-        # lf: crashes redis server
-        # fg: crashes redis server
-        # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-        # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-        # tcg: https://github.com/bazelbuild/bazel/issues/19295 bazel5 is required but unavailable
-        run: ./build-bench-env.sh all no-lean no-mi no-mesh no-nomesh no-gd no-rp no-lf no-fg no-pa no-lp no-sh8 no-tcg
-      - name: Run everything.
-        run: |
-          cd out/bench
-          ../../bench.sh alla allt
-  build-all-osx:
-    runs-on: macos-11
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@v3
-      - name: Silence some git warnings
-        run: |
-          git config --global advice.detachedHead false
-          git config --global init.defaultBranch main
-      - name: Install and build all benchmarks and allocators
-        # ff:ffmalloc.c:1140:14: error: implicit declaration of function 'sched_getcpu' is invalid in C99 [-Werror,-Wimplicit-function-declaration] 
-        # fg: unknown type name 'pthread_spinlock_t'; did you mean 'pthread_rwlock_t'?
-        # gd: so many errors
-        # pa: ninja: error: '../../buildtools/third_party/libc++/trunk/src/utility.cpp', needed by 'obj/buildtools/third_party/libc++/libc++/utility.o', missing and no known rule to make it
-        # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-        run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-pa no-lp
-      - name: Run everything.
-        run: |
-          cd out/bench
-          ../../bench.sh alla allt
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and run benchmarks in Docker
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          target: benchmark
+          build-args: |
+            allocator=${{ matrix.allocator }}
+            benchs=allt
+            repeats=1
+          cache-from: type=gha
+
+  # build-all-alpine:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: alpine:latest
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v3
+  #     - name: Install bash
+  #       run: apk add bash git
+  #     - name: Silence some git warnings
+  #       run: |
+  #         git config --global advice.detachedHead false
+  #         git config --global init.defaultBranch main
+  #     - name: Install and build all benchmarks and allocators
+  #       # dh: glibc-specific
+  #       # fg: Uses execinfo.h, which is a GNU extension
+  #       # gd: ?
+  #       # hd: glibc-specific
+  #       # lf: crashes redis server
+  #       # lt: return type 'struct mallinfo' is incomplete
+  #       # mesh/nomesh: infinite loop?
+  #       # pa: can't setup depot_tools and goma
+  #       # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
+  #       # tcg: [...] specifies less restrictive attribute than its target [...]
+  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  #       # rp: rpmalloc/rpmalloc.c:980:9: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
+  #       run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-pa no-gd no-fg no-lf no-lt no-tcg no-lp no-rp
+  #     - name: Run everything.
+  #       run: |
+  #         cd out/bench
+  #         ../../bench.sh alla allt
+  # build-all-ubuntu:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v3
+  #     - name: Silence some git warnings
+  #       run: |
+  #         git config --global advice.detachedHead false
+  #         git config --global init.defaultBranch main
+  #     - name: Install and build all benchmarks and allocators
+  #       # fg: crashes on redis
+  #       # gd: infinite loop in the redis benchmark
+  #       # lt: breaks on sh8benchN
+  #       # lf: crashes redis server
+  #       # ff: crashes on modern ubuntu: https://github.com/bwickman97/ffmalloc/issues/5
+  #       # hoard: crashes on rocksdb
+  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
+  #       # sn: /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
+  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
+  #       # tcg: ERROR: Error computing the main repository mapping: protobuf@29.0 depends on rules_fuzzing@0.5.2 with compatibility level 0, but <root> depends on rules_fuzzing@0.5.1 with compatibility level 1 which is different
+  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-lt no-lf no-hd no-pa no-sn no-lp no-tcg
+  #     - name: Run everything.
+  #       run: |
+  #         cd out/bench
+  #         ../../bench.sh alla allt
+  # build-all-fedora:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: fedora:latest
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v3
+  #     - name: Install git
+  #       run: sudo dnf -y --quiet --nodocs install git
+  #     - name: Silence some git warnings
+  #       run: |
+  #         git config --global advice.detachedHead false
+  #         git config --global init.defaultBranch main
+  #     - name: Install and build all benchmarks and allocators
+  #       # gd: infinite loop in the redis benchmark
+  #       # mesh/nomesh: error: '__malloc_hook' was not declared in this scope;
+  #       # mi: error: '__malloc_hook' was not declared in this scope;
+  #       # rp: mixing declarations and code is incompatible with standards before C99
+  #       # lf: crashes redis server
+  #       # fg: crashes redis server
+  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
+  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+  #       # tcg: https://github.com/bazelbuild/bazel/issues/19295 bazel5 is required but unavailable
+  #       run: ./build-bench-env.sh all no-lean no-mi no-mesh no-nomesh no-gd no-rp no-lf no-fg no-pa no-lp no-sh8 no-tcg
+  #     - name: Run everything.
+  #       run: |
+  #         cd out/bench
+  #         ../../bench.sh alla allt
+  # build-all-osx:
+  #   runs-on: macos-11
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v3
+  #     - name: Silence some git warnings
+  #       run: |
+  #         git config --global advice.detachedHead false
+  #         git config --global init.defaultBranch main
+  #     - name: Install and build all benchmarks and allocators
+  #       # ff:ffmalloc.c:1140:14: error: implicit declaration of function 'sched_getcpu' is invalid in C99 [-Werror,-Wimplicit-function-declaration] 
+  #       # fg: unknown type name 'pthread_spinlock_t'; did you mean 'pthread_rwlock_t'?
+  #       # gd: so many errors
+  #       # pa: ninja: error: '../../buildtools/third_party/libc++/trunk/src/utility.cpp', needed by 'obj/buildtools/third_party/libc++/libc++/utility.o', missing and no known rule to make it
+  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
+  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-pa no-lp
+  #     - name: Run everything.
+  #       run: |
+  #         cd out/bench
+  #         ../../bench.sh alla allt

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,8 +28,8 @@ jobs:
           target: bench-env
           build-args: |
             platform=${{ matrix.platform }}
-          cache-from: type=gha,index=buildkit_${{ matrix.platform }}
-          cache-to: type=gha,mode=max, index=buildkit_${{ matrix.platform }}
+          cache-from: type=gha,scope=buildkit_${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=buildkit_${{ matrix.platform }}
 
   build-and-benchmark-allocator:
     runs-on: ubuntu-latest
@@ -58,7 +58,7 @@ jobs:
             allocator=${{ matrix.allocator }}
             benchs=allt
             repeats=1
-          cache-from: type=gha, index=buildkit_${{ matrix.platform }}
+          cache-from: type=gha,scope=buildkit_${{ matrix.platform }}
 
   # build-all-alpine:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build-base-with-docker:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [ubuntu:24.04, alpine:latest, fedora:latest]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -24,16 +27,17 @@ jobs:
           tags: bench
           target: bench-env
           build-args: |
-            platform=ubuntu:24.04
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            platform=${{ matrix.platform }}
+          cache-from: type=gha,index=buildkit_${{ matrix.platform }}
+          cache-to: type=gha,mode=max, index=buildkit_${{ matrix.platform }}
 
   build-and-benchmark-allocator:
     runs-on: ubuntu-latest
     needs: build-base-with-docker
     strategy:
       matrix:
-        allocator: [mi, sn]
+        platform: [ubuntu:24.04, alpine:latest, fedora:latest]
+        allocator: [mi, sn, je]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -50,11 +54,11 @@ jobs:
           push: false
           target: benchmark
           build-args: |
-            platform=ubuntu:24.04
+            platform=${{ matrix.platform }}
             allocator=${{ matrix.allocator }}
             benchs=allt
             repeats=1
-          cache-from: type=gha
+          cache-from: type=gha, index=buildkit_${{ matrix.platform }}
 
   # build-all-alpine:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -1,9 +1,17 @@
 name: Build and run everything
+
+# The following should ensure that the workflow only runs a single set of actions
+# for each PR. But it will not apply this to pushes to the main branch.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 on:
   push:
   pull_request:
   schedule:
     - cron: '0 0 * * 1'
+
 jobs:
   build-and-run:
     strategy:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,9 +28,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build-base-with-docker_again:
+  build-and-benchmark-allocator:
     runs-on: ubuntu-latest
     needs: build-base-with-docker
+    strategy:
+      matrix:
+        allocator: [mi, sn]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -38,48 +41,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build benchmarks in Docker
+      - name: Build allocator and run benchmarks in Docker
         id: docker_build
         uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile
           push: false
-          tags: bench
-          target: bench-env
+          target: benchmark
           build-args: |
             platform=ubuntu:24.04
+            allocator=${{ matrix.allocator }}
+            benchs=allt
+            repeats=1
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-
-  # build-and-benchmark-allocator:
-  #   runs-on: ubuntu-latest
-  #   needs: build-base-with-docker
-  #   strategy:
-  #     matrix:
-  #       allocator: [mi, sn]
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-
-  #     - name: Build allocator and run benchmarks in Docker
-  #       id: docker_build
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         context: .
-  #         file: Dockerfile
-  #         push: false
-  #         target: benchmark
-  #         build-args: |
-  #           platform=ubuntu:24.04
-  #           allocator=${{ matrix.allocator }}
-  #           benchs=allt
-  #           repeats=1
-  #         cache-from: type=gha
 
   # build-all-alpine:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-run:
     strategy:
       matrix:
-        platform: [ubuntu:24.04, fedora:latest]
+        platform: [ubuntu, fedora, alpine]
       fail-fast: false
     uses: ./.github/workflows/platform.yml
     name: ${{ matrix.platform }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -36,7 +36,7 @@ jobs:
     needs: build-base-with-docker
     strategy:
       matrix:
-        platform: [ubuntu:24.04, alpine:latest, fedora:latest]
+        platform: [ubuntu:24.04, fedora:latest]
         allocator: [mi, sn, je]
     steps:
       - name: Check out repository code

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        platform: [ubuntu:24.04, alpine:latest, fedora:latest]
+        platform: [ubuntu:24.04, fedora:latest]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -28,12 +28,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  build-and-benchmark-allocator:
+  build-base-with-docker_again:
     runs-on: ubuntu-latest
     needs: build-base-with-docker
-    strategy:
-      matrix:
-        allocator: [mi, sn]
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -41,20 +38,48 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Build allocator and run benchmarks in Docker
+      - name: Build benchmarks in Docker
         id: docker_build
         uses: docker/build-push-action@v4
         with:
           context: .
           file: Dockerfile
           push: false
-          target: benchmark
+          tags: bench
+          target: bench-env
           build-args: |
             platform=ubuntu:24.04
-            allocator=${{ matrix.allocator }}
-            benchs=allt
-            repeats=1
           cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+  # build-and-benchmark-allocator:
+  #   runs-on: ubuntu-latest
+  #   needs: build-base-with-docker
+  #   strategy:
+  #     matrix:
+  #       allocator: [mi, sn]
+  #   steps:
+  #     - name: Check out repository code
+  #       uses: actions/checkout@v3
+
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+
+  #     - name: Build allocator and run benchmarks in Docker
+  #       id: docker_build
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         context: .
+  #         file: Dockerfile
+  #         push: false
+  #         target: benchmark
+  #         build-args: |
+  #           platform=ubuntu:24.04
+  #           allocator=${{ matrix.allocator }}
+  #           benchs=allt
+  #           repeats=1
+  #         cache-from: type=gha
 
   # build-all-alpine:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -8,114 +8,12 @@ jobs:
   build-and-run:
     strategy:
       matrix:
-        platform: [ubuntu, alpine] # Dropped fedora as not currently building lean.
+        platform: [ubuntu, alpine, fedora]
+        exclude:
+          # Fedora is not currently building lean.
+          - platform: fedora
       fail-fast: false
     uses: ./.github/workflows/platform.yml
     name: ${{ matrix.platform }}
     with:
       platform: ${{ matrix.platform }}
-
-  # build-all-alpine:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: alpine:latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Install bash
-  #       run: apk add bash git
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # dh: glibc-specific
-  #       # fg: Uses execinfo.h, which is a GNU extension
-  #       # gd: ?
-  #       # hd: glibc-specific
-  #       # lf: crashes redis server
-  #       # lt: return type 'struct mallinfo' is incomplete
-  #       # mesh/nomesh: infinite loop?
-  #       # pa: can't setup depot_tools and goma
-  #       # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
-  #       # tcg: [...] specifies less restrictive attribute than its target [...]
-  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-  #       # rp: rpmalloc/rpmalloc.c:980:9: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
-  #       run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-pa no-gd no-fg no-lf no-lt no-tcg no-lp no-rp
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-ubuntu:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # fg: crashes on redis
-  #       # gd: infinite loop in the redis benchmark
-  #       # lt: breaks on sh8benchN
-  #       # lf: crashes redis server
-  #       # ff: crashes on modern ubuntu: https://github.com/bwickman97/ffmalloc/issues/5
-  #       # hoard: crashes on rocksdb
-  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-  #       # sn: /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
-  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-  #       # tcg: ERROR: Error computing the main repository mapping: protobuf@29.0 depends on rules_fuzzing@0.5.2 with compatibility level 0, but <root> depends on rules_fuzzing@0.5.1 with compatibility level 1 which is different
-  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-lt no-lf no-hd no-pa no-sn no-lp no-tcg
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-fedora:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: fedora:latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Install git
-  #       run: sudo dnf -y --quiet --nodocs install git
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # gd: infinite loop in the redis benchmark
-  #       # mesh/nomesh: error: '__malloc_hook' was not declared in this scope;
-  #       # mi: error: '__malloc_hook' was not declared in this scope;
-  #       # rp: mixing declarations and code is incompatible with standards before C99
-  #       # lf: crashes redis server
-  #       # fg: crashes redis server
-  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-  #       # tcg: https://github.com/bazelbuild/bazel/issues/19295 bazel5 is required but unavailable
-  #       run: ./build-bench-env.sh all no-lean no-mi no-mesh no-nomesh no-gd no-rp no-lf no-fg no-pa no-lp no-sh8 no-tcg
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-osx:
-  #   runs-on: macos-11
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # ff:ffmalloc.c:1140:14: error: implicit declaration of function 'sched_getcpu' is invalid in C99 [-Werror,-Wimplicit-function-declaration] 
-  #       # fg: unknown type name 'pthread_spinlock_t'; did you mean 'pthread_rwlock_t'?
-  #       # gd: so many errors
-  #       # pa: ninja: error: '../../buildtools/third_party/libc++/trunk/src/utility.cpp', needed by 'obj/buildtools/third_party/libc++/libc++/utility.o', missing and no known rule to make it
-  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-pa no-lp
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -8,7 +8,7 @@ jobs:
   build-and-run:
     strategy:
       matrix:
-        platform: [ubuntu, fedora, alpine]
+        platform: [ubuntu, alpine] # Dropped fedora as not currently building lean.
       fail-fast: false
     uses: ./.github/workflows/platform.yml
     name: ${{ matrix.platform }}

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -24,8 +24,7 @@ jobs:
           tags: bench
           target: bench-env
           build-args: |
-            platform=ubuntu
-            platform_version=24.04
+            platform=ubuntu:24.04
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -51,8 +50,7 @@ jobs:
           push: false
           target: benchmark
           build-args: |
-            platform=ubuntu
-            platform_version=24.04
+            platform=ubuntu:24.04
             allocator=${{ matrix.allocator }}
             benchs=allt
             repeats=1

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -11,6 +11,7 @@ jobs:
         platform: [ubuntu:24.04, fedora:latest]
       fail-fast: false
     uses: ./.github/workflows/platform.yml
+    name: ${{ matrix.platform }}
     with:
       platform: ${{ matrix.platform }}
 

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -51,6 +51,8 @@ jobs:
           push: false
           target: benchmark
           build-args: |
+            platform=ubuntu
+            platform_version=24.04
             allocator=${{ matrix.allocator }}
             benchs=allt
             repeats=1

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,15 +38,15 @@ jobs:
     strategy:
       matrix:
         allocator: [mi, sn, je, dh, hd]
-        true: [true, false]
+        pedicate: [true, false]
         exclude:
-          - true: false
+          - predicate: false
           # dh: glibc-specific
           - allocator: dh
-            platform: ${{ inputs.platform == 'alpine' }}
+            predicate: ${{ inputs.platform == 'alpine' }}
           # hd: glibc-specific
           - allocator: hd
-            platform: ${{ inputs.platform == 'alpine' }}
+            predicate: ${{ inputs.platform == 'alpine' }}
 
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -37,12 +37,15 @@ jobs:
     needs: build-base-with-docker
     strategy:
       matrix:
-        allocator: [mi, sn, je, dh, hd]
+        allocator: [ff, fg, gd, hd, hm, iso, je, lf, lp, lt, mesh, mng, mi, mi2, nomesh, pa, rp, scudo, sm, sn, sg, tbb, tc, yal, tcg]
         predicate: [true, false]
         exclude:
           - predicate: false
           # dh: glibc-specific
           - allocator: dh
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # fg: Uses execinfo.h, which is a GNU extension
+          - allocator: fg
             predicate: ${{ inputs.platform == 'alpine' }}
           # hd: glibc-specific
           - allocator: hd

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -75,9 +75,6 @@ jobs:
           # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
           - allocator: sm
             predicate: ${{ inputs.platform == 'alpine' }}
-          # sn: __cxa_thread_at_exit_impl is not available in musl
-          - allocator: sn
-            predicate: ${{ inputs.platform == 'alpine' }}
           # tcg: [...] specifies less restrictive attribute than its target [...]
           - allocator: tcg
             predicate: ${{ inputs.platform == 'alpine' }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -39,19 +39,14 @@ jobs:
       matrix:
         allocator: [ff, fg, gd, hd, hm, iso, je, lf, lp, lt, mesh, mng, mi, mi2, nomesh, pa, rp, scudo, sm, sn, sg, tbb, tc, yal, tcg]
         testsuite: [allt]
+        # Used to provide a platform-specific predicate
         predicate: [true, false]
         exclude:
+          # Always exclude build when predicate is false.
           - predicate: false
+
           # Not currently working on any platform
           - allocator: pa
-
-          # Following allocators are failing redis testsuite
-          - testsuite: allt
-            allocator: fg
-          - testsuite: allt
-            allocator: gd
-          - testsuite: allt
-            allocator: lf
 
           # Alpine Specific disables.
           # dh: glibc-specific
@@ -78,17 +73,6 @@ jobs:
           # tcg: [...] specifies less restrictive attribute than its target [...]
           - allocator: tcg
             predicate: ${{ inputs.platform == 'alpine' }}
-        include:
-          # Following allocators are failing redis testsuite
-          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
-            allocator: lf
-          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
-            allocator: fg
-          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
-            allocator: gd
-          
-
-
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark
     steps:
@@ -106,9 +90,10 @@ jobs:
           file: Dockerfile
           push: false
           target: benchmark
+          ## If allocators in lf,fg,gd then use a smaller set of tests.
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=${{ matrix.testsuite }}
+            benchs=${{ contains('lf,fg,gd', matrix.allocator) && 'cfrac espresso barnes lean larson-sized mstress rptest gs lua' || 'allt' }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,7 +38,18 @@ jobs:
     needs: build-base-with-docker
     strategy:
       matrix:
-        allocator: [mi, sn, je]
+        allocator: [mi, sn, je, dh, hd]
+        isAlpine: ${{ inputs.platform == 'alpine' }}
+        isFedora: ${{ inputs.platform == 'fedora' }}
+        isUbuntu: ${{ inputs.platform == 'ubuntu' }}
+        exclude:
+          # dh: glibc-specific
+          - allocator: dh
+            isAlpine: true
+          # hd: glibc-specific
+          - allocator: hd
+            isAlpine: true
+
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark
     steps:

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,11 +38,20 @@ jobs:
     strategy:
       matrix:
         allocator: [ff, fg, gd, hd, hm, iso, je, lf, lp, lt, mesh, mng, mi, mi2, nomesh, pa, rp, scudo, sm, sn, sg, tbb, tc, yal, tcg]
+        testsuite: [allt]
         predicate: [true, false]
         exclude:
           - predicate: false
           # Not currently working on any platform
           - allocator: pa
+
+          # Following allocators are failing redis testsuite
+          - testsuite: allt
+            allocator: fg
+          - testsuite: allt
+            allocator: gd
+          - testsuite: allt
+            allocator: lf
 
           # Alpine Specific disables.
           # dh: glibc-specific
@@ -72,6 +81,16 @@ jobs:
           # tcg: [...] specifies less restrictive attribute than its target [...]
           - allocator: tcg
             predicate: ${{ inputs.platform == 'alpine' }}
+        include:
+          # Following allocators are failing redis testsuite
+          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
+            allocator: lf
+          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
+            allocator: fg
+          - testsuite: cfrac espresso barnes lean larson-sized mstress rptest gs lua
+            allocator: gd
+          
+
 
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark
@@ -93,6 +112,6 @@ jobs:
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=allt
+            benchs=${{ matrix.testsuite }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -41,14 +41,36 @@ jobs:
         predicate: [true, false]
         exclude:
           - predicate: false
+          # Not currently working on any platform
+          - allocator: pa
+
+          # Alpine Specific disables.
           # dh: glibc-specific
           - allocator: dh
             predicate: ${{ inputs.platform == 'alpine' }}
           # fg: Uses execinfo.h, which is a GNU extension
           - allocator: fg
             predicate: ${{ inputs.platform == 'alpine' }}
+          # gd: ?
+          - allocator: gd
+            predicate: ${{ inputs.platform == 'alpine' }}
           # hd: glibc-specific
           - allocator: hd
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
+          - allocator: lp
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # lt: return type 'struct mallinfo' is incomplete
+          - allocator: lt
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
+          - allocator: sm
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # sn: __cxa_thread_at_exit_impl is not available in musl
+          - allocator: sn
+            predicate: ${{ inputs.platform == 'alpine' }}
+          # tcg: [...] specifies less restrictive attribute than its target [...]
+          - allocator: tcg
             predicate: ${{ inputs.platform == 'alpine' }}
 
       fail-fast: false
@@ -74,108 +96,3 @@ jobs:
             benchs=allt
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}
-
-  # build-all-alpine:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: alpine:latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Install bash
-  #       run: apk add bash git
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # dh: glibc-specific
-  #       # fg: Uses execinfo.h, which is a GNU extension
-  #       # gd: ?
-  #       # hd: glibc-specific
-  #       # lf: crashes redis server
-  #       # lt: return type 'struct mallinfo' is incomplete
-  #       # mesh/nomesh: infinite loop?
-  #       # pa: can't setup depot_tools and goma
-  #       # sm: ../src/supermalloc.h:10:31: error: expected initializer before '__THROW'
-  #       # tcg: [...] specifies less restrictive attribute than its target [...]
-  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-  #       # rp: rpmalloc/rpmalloc.c:980:9: error: unsafe pointer arithmetic [-Werror,-Wunsafe-buffer-usage]
-  #       run: ./build-bench-env.sh all no-dh no-hd no-sm no-mesh no-nomesh no-pa no-gd no-fg no-lf no-lt no-tcg no-lp no-rp
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-ubuntu:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # fg: crashes on redis
-  #       # gd: infinite loop in the redis benchmark
-  #       # lt: breaks on sh8benchN
-  #       # lf: crashes redis server
-  #       # ff: crashes on modern ubuntu: https://github.com/bwickman97/ffmalloc/issues/5
-  #       # hoard: crashes on rocksdb
-  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-  #       # sn: /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/chrono:2320:48: error: call to consteval function 'std::chrono::hh_mm_ss::_S_fractional_width' is not a constant expression
-  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-  #       # tcg: ERROR: Error computing the main repository mapping: protobuf@29.0 depends on rules_fuzzing@0.5.2 with compatibility level 0, but <root> depends on rules_fuzzing@0.5.1 with compatibility level 1 which is different
-  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-lt no-lf no-hd no-pa no-sn no-lp no-tcg
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-fedora:
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: fedora:latest
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Install git
-  #       run: sudo dnf -y --quiet --nodocs install git
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # gd: infinite loop in the redis benchmark
-  #       # mesh/nomesh: error: '__malloc_hook' was not declared in this scope;
-  #       # mi: error: '__malloc_hook' was not declared in this scope;
-  #       # rp: mixing declarations and code is incompatible with standards before C99
-  #       # lf: crashes redis server
-  #       # fg: crashes redis server
-  #       # pa: python3: can't open file '/__w/mimalloc-bench/mimalloc-bench/extern/pa/partition_alloc_builder/tools/rust/update_rust.py': [Errno 2] No such file or directory
-  #       # lp: /__w/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/pas_thread_local_cache.c:218:22: error: call to undeclared function 'pthread_getname_np'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
-  #       # tcg: https://github.com/bazelbuild/bazel/issues/19295 bazel5 is required but unavailable
-  #       run: ./build-bench-env.sh all no-lean no-mi no-mesh no-nomesh no-gd no-rp no-lf no-fg no-pa no-lp no-sh8 no-tcg
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt
-  # build-all-osx:
-  #   runs-on: macos-11
-  #   steps:
-  #     - name: Check out repository code
-  #       uses: actions/checkout@v3
-  #     - name: Silence some git warnings
-  #       run: |
-  #         git config --global advice.detachedHead false
-  #         git config --global init.defaultBranch main
-  #     - name: Install and build all benchmarks and allocators
-  #       # ff:ffmalloc.c:1140:14: error: implicit declaration of function 'sched_getcpu' is invalid in C99 [-Werror,-Wimplicit-function-declaration] 
-  #       # fg: unknown type name 'pthread_spinlock_t'; did you mean 'pthread_rwlock_t'?
-  #       # gd: so many errors
-  #       # pa: ninja: error: '../../buildtools/third_party/libc++/trunk/src/utility.cpp', needed by 'obj/buildtools/third_party/libc++/libc++/utility.o', missing and no known rule to make it
-  #       # lp: /home/runner/work/mimalloc-bench/mimalloc-bench/extern/lp/Source/bmalloc/libpas/src/libpas/hotbit_heap_inlines.h:64:51: error: too few arguments to function call, expected 3, have 2
-  #       run: ./build-bench-env.sh all no-lean no-gd no-ff no-fg no-pa no-lp
-  #     - name: Run everything.
-  #       run: |
-  #         cd out/bench
-  #         ../../bench.sh alla allt

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build-base-with-docker:
     runs-on: ubuntu-latest
+    name: Base Container
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
@@ -39,6 +40,7 @@ jobs:
       matrix:
         allocator: [mi, sn, je]
       fail-fast: false
+    name: ${{ matrix.allocator }} - build and benchmark
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -1,18 +1,65 @@
 name: Build and run everything
 on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 0 * * 1'
+  workflow_call:
+    inputs:
+      platform:
+        description: 'Base container image to build on'
+        required: true
+        type: string
+
 jobs:
-  build-and-run:
+  build-base-with-docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build benchmarks in Docker
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          tags: bench
+          target: bench-env
+          build-args: |
+            platform=${{ inputs.platform }}
+          cache-from: type=gha,scope=buildkit_${{ inputs.platform }}
+          cache-to: type=gha,mode=max,scope=buildkit_${{ inputs.platform }}
+
+  build-and-benchmark-allocator:
+    runs-on: ubuntu-latest
+    
+    needs: build-base-with-docker
     strategy:
       matrix:
-        platform: [ubuntu:24.04, fedora:latest]
+        allocator: [mi, sn, je]
       fail-fast: false
-    uses: ./.github/workflows/platform.yml
-    with:
-      platform: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build allocator and run benchmarks in Docker
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          target: benchmark
+          build-args: |
+            platform=${{ inputs.platform }}
+            allocator=${{ matrix.allocator }}
+            benchs=allt
+            repeats=1
+          cache-from: type=gha,scope=buildkit_${{ inputs.platform }}
 
   # build-all-alpine:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -90,10 +90,11 @@ jobs:
           file: Dockerfile
           push: false
           target: benchmark
-          ## If allocators in lf,fg,gd then use a smaller set of tests.
+          ## If allocators in lt,lf,fg,gd then use a smaller set of tests.
+          ## They were generally failing on lean or redis, and lf was also failing on mstress.
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=${{ (contains('lf,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua') || ('fg' == matrix.allocator && 'cfrac espresso barnes mstress rptest gs lua') || 'allt' }}
+            benchs=${{ (contains('lt,lf,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua') || ('fg' == matrix.allocator && 'cfrac espresso barnes rptest gs lua') || 'allt' }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,14 +38,15 @@ jobs:
     strategy:
       matrix:
         allocator: [mi, sn, je, dh, hd]
-        platform: ${{ inputs.platform }}
+        true: [true, false]
         exclude:
+          - true: false
           # dh: glibc-specific
           - allocator: dh
-            platform: alpine
+            platform: ${{ inputs.platform == 'alpine' }}
           # hd: glibc-specific
           - allocator: hd
-            platform: alpine
+            platform: ${{ inputs.platform == 'alpine' }}
 
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -94,6 +94,6 @@ jobs:
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=${{ contains('lf,fg,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua' || 'allt' }}
+            benchs=${{ (contains('lf,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua') || ('fg' == matrix.allocator && 'cfrac espresso barnes mstress rptest gs lua') || 'allt' }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -77,7 +77,7 @@ jobs:
     name: ${{ matrix.allocator }} - build and benchmark
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -94,6 +94,6 @@ jobs:
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=${{ contains('lf,fg,gd', matrix.allocator) && 'cfrac espresso barnes lean larson-sized mstress rptest gs lua' || 'allt' }}
+            benchs=${{ contains('lf,fg,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua' || 'allt' }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         allocator: [mi, sn, je, dh, hd]
-        pedicate: [true, false]
+        predicate: [true, false]
         exclude:
           - predicate: false
           # dh: glibc-specific

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -95,6 +95,6 @@ jobs:
           build-args: |
             platform=${{ inputs.platform }}
             allocator=${{ matrix.allocator }}
-            benchs=${{ (contains('lt,lf,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua') || ('fg' == matrix.allocator && 'cfrac espresso barnes rptest gs lua') || 'allt' }}
+            benchs=${{ (contains('lt,lf,gd', matrix.allocator) && 'cfrac espresso barnes larson-sized mstress rptest gs lua') || ('fg' == matrix.allocator && 'cfrac espresso barnes gs lua') || 'allt' }}
             repeats=1
           cache-from: type=gha,scope=buildkit_${{ inputs.platform }}

--- a/.github/workflows/platform.yml
+++ b/.github/workflows/platform.yml
@@ -34,21 +34,18 @@ jobs:
 
   build-and-benchmark-allocator:
     runs-on: ubuntu-latest
-    
     needs: build-base-with-docker
     strategy:
       matrix:
         allocator: [mi, sn, je, dh, hd]
-        isAlpine: ${{ inputs.platform == 'alpine' }}
-        isFedora: ${{ inputs.platform == 'fedora' }}
-        isUbuntu: ${{ inputs.platform == 'ubuntu' }}
+        platform: ${{ inputs.platform }}
         exclude:
           # dh: glibc-specific
           - allocator: dh
-            isAlpine: true
+            platform: alpine
           # hd: glibc-specific
           - allocator: hd
-            isAlpine: true
+            platform: alpine
 
       fail-fast: false
     name: ${{ matrix.allocator }} - build and benchmark

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+ARG platform=ubuntu
+ARG platform_version=24.04
+
+FROM ${platform}:${platform_version} as bench-env
+
+# Pull mimalloc-bench
+RUN mkdir -p /mimalloc-bench
+COPY . /mimalloc-bench
+
+WORKDIR /mimalloc-bench
+# Install dependencies
+RUN ./build-bench-env.sh packages
+
+# Build benchmarks
+RUN ./build-bench-env.sh bench
+
+RUN ./build-bench-env.sh redis
+
+RUN ./build-bench-env.sh rocksdb
+
+RUN ./build-bench-env.sh lean
+
+
+FROM bench-env as benchmark
+
+WORKDIR /mimalloc-bench
+
+ARG allocator=mi
+ARG benchs=allt
+ARG repeats=1
+
+RUN ./build-bench-env.sh $allocator
+
+# Run benchmarks
+WORKDIR /mimalloc-bench/out/bench
+RUN ../../bench.sh $allocator $benchs -r=$repeats

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${platform}:${platform_version} as bench-env
 
 # Pull mimalloc-bench
 RUN mkdir -p /mimalloc-bench
-COPY --exclude=.github . /mimalloc-bench
+COPY . /mimalloc-bench
 
 WORKDIR /mimalloc-bench
 # Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-ARG platform=ubuntu:24.04
+ARG platform=ubuntu
+
+FROM ubuntu:24.04 AS ubuntu
+
+
+FROM fedora:latest AS fedora
+
+
+FROM alpine:latest AS alpine
+RUN apk add --no-cache bash
+
 
 FROM ${platform} AS bench-env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${platform}:${platform_version} as bench-env
 
 # Pull mimalloc-bench
 RUN mkdir -p /mimalloc-bench
-COPY . /mimalloc-bench
+COPY --exclude .github . /mimalloc-bench
 
 WORKDIR /mimalloc-bench
 # Install dependencies
@@ -14,11 +14,11 @@ RUN ./build-bench-env.sh packages
 # Build benchmarks
 RUN ./build-bench-env.sh bench
 
-RUN ./build-bench-env.sh redis
+# RUN ./build-bench-env.sh redis
 
-RUN ./build-bench-env.sh rocksdb
+# RUN ./build-bench-env.sh rocksdb
 
-RUN ./build-bench-env.sh lean
+# RUN ./build-bench-env.sh lean
 
 
 FROM bench-env as benchmark
@@ -26,7 +26,7 @@ FROM bench-env as benchmark
 WORKDIR /mimalloc-bench
 
 ARG allocator=mi
-ARG benchs=allt
+ARG benchs=cfrac
 ARG repeats=1
 
 RUN ./build-bench-env.sh $allocator

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG platform=ubuntu
-ARG platform_version=24.04
+ARG platform=ubuntu:24.04
 
-FROM ${platform}:${platform_version} as bench-env
+FROM ${platform} AS bench-env
 
 # Pull mimalloc-bench
 RUN mkdir -p /mimalloc-bench
@@ -21,7 +20,7 @@ RUN ./build-bench-env.sh bench
 # RUN ./build-bench-env.sh lean
 
 
-FROM bench-env as benchmark
+FROM bench-env AS benchmark
 
 WORKDIR /mimalloc-bench
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,11 @@ RUN ./build-bench-env.sh packages
 # Build benchmarks
 RUN ./build-bench-env.sh bench
 
-# RUN ./build-bench-env.sh redis
+RUN ./build-bench-env.sh redis
 
-# RUN ./build-bench-env.sh rocksdb
+RUN ./build-bench-env.sh rocksdb
 
-# RUN ./build-bench-env.sh lean
-
+RUN ./build-bench-env.sh lean
 
 FROM bench-env AS benchmark
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${platform}:${platform_version} as bench-env
 
 # Pull mimalloc-bench
 RUN mkdir -p /mimalloc-bench
-COPY --exclude .github . /mimalloc-bench
+COPY --exclude=.github . /mimalloc-bench
 
 WORKDIR /mimalloc-bench
 # Install dependencies

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -656,7 +656,7 @@ if test "$setup_sn" = "1"; then
   else
     mkdir -p release
     cd release
-    env CXX=clang++ cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release
+    env CXX=clang++ cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -
     cd ..
   fi
   cd release

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -441,7 +441,7 @@ if test "$setup_packages" = "1"; then
     # no 'apt update' equivalent needed on Fedora
     dnfinstall "gcc-c++ clang lld llvm-devel unzip dos2unix bc gmp-devel wget gawk \
       cmake python3 ruby ninja-build libtool autoconf git patch time sed \
-      ghostscript libatomic which gflags-devel xz readline-devel snappy-devel"
+      ghostscript libatomic libstdc++ which gflags-devel xz readline-devel snappy-devel"
     # bazel5 is broken on the copr: https://github.com/bazelbuild/bazel/issues/19295
     #dnfinstallbazel
   elif grep -q -e 'ID=debian' -e 'ID=ubuntu' /etc/os-release 2>/dev/null; then

--- a/build-bench-env.sh
+++ b/build-bench-env.sh
@@ -656,7 +656,8 @@ if test "$setup_sn" = "1"; then
   else
     mkdir -p release
     cd release
-    env CXX=clang++ cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -
+    # CXX11_DESTRUCTORS is needed as broken on Alpine without, should be fixed in the future upstrem.
+    env CXX=clang++ cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DSNMALLOC_CLEANUP=CXX11_DESTRUCTORS
     cd ..
   fi
   cd release


### PR DESCRIPTION
Based on my experiments for snmalloc's CI. I have quickly knocked together a similar approach to enable sharing across build steps, and increase parallelism.

@derSteFfi I in no way mean this to replace your work on #243.  I think these could be used together.  Though, with what you have `ccache` would probably work better than docker here.