### PR TITLE
larson: fix two intermittent completion hangs

### DIFF
--- a/bench/larson/larson.cpp
+++ b/bench/larson/larson.cpp
@@ -75,6 +75,7 @@ void QueryPerformanceFrequency(long * x)
 #include  <ctype.h>
 #include  <time.h>
 #include  <assert.h>
+#include  <atomic>
 
 #define _REENTRANT 1
 #include <pthread.h>
@@ -158,7 +159,14 @@ void operator delete[](void *pUserData )
 #define MAX_THREADS     100
 #define MAX_BLOCKS  1000000
 
-int volatile  stopflag=FALSE ;
+// stopflag and thread_data::finished are shared between the main thread
+// (runthreads: sets stopflag, then spins on each finished) and the worker /
+// respawn threads (exercise_heap: reads stopflag, writes finished).  As plain
+// `volatile int` these accesses are an unsynchronized data race (UB) — volatile
+// provides neither atomicity nor inter-thread ordering.  ThreadSanitizer flags
+// the stopflag and finished races, and the race can strand a slot's `finished`
+// at FALSE after a respawn, hanging the completion loop forever.  Use atomics.
+std::atomic<int> stopflag{FALSE} ;
 
 struct lran2_st {
   long x, y, v[97];
@@ -184,7 +192,7 @@ typedef struct thr_data {
   long   cThreads ;
   long   cBytesAlloced ;
 
-  volatile int finished ;
+  std::atomic<int> finished ;   // was `volatile int`; raced main<->workers (see stopflag note above)
   struct lran2_st rgen ;
 
 } thread_data;
@@ -586,9 +594,14 @@ static void * exercise_heap( void *pinput)
   size_t        blk_size;
   int           range ;
 
-  if( stopflag ) return 0;
-
+  // A worker that starts after main has set stopflag=TRUE must still mark its slot
+  // finished, otherwise main's `while(!de_area[i].finished)` completion loop waits on
+  // it forever.  The original `return 0` left finished at its initial 0 — a hang that
+  // shows up when thread startup is slow enough to deliver a just-created worker after
+  // stopflag is set (the stuck slot has cThreads==cAllocs==0: it never entered the loop).
   pdea = (thread_data *)pinput ;
+  if( stopflag ){ pdea->finished = TRUE ; return 0; }
+
   pdea->finished = FALSE ;
   pdea->cThreads++ ;
   range = pdea->max_size - pdea->min_size ;


### PR DESCRIPTION
`runthreads()` waits for the worker threads by spinning on each slot's `finished` flag (`while (!de_area[i].finished) sched_yield();`). Two bugs can leave a slot's `finished` false forever, so `larson`/`larson-sized` occasionally **hang** at shutdown instead of finishing.

Both are latent, timing-dependent races: they surface when thread startup/scheduling is slow enough to widen the window (I hit them consistently under a GC-based allocator whose per-thread setup delays a worker past `stopflag`; the system allocator misses the window by luck). They are allocator-independent bugs in the harness itself.

**1. Data race on `stopflag` / `finished`.** Both are shared between the main thread (sets `stopflag`, reads `finished`) and the worker/respawn threads (read `stopflag`, write `finished`) as plain `volatile int`. `volatile` gives neither atomicity nor inter-thread ordering, so these are unsynchronized data races (UB). ThreadSanitizer flags both (on a standalone build with the system allocator — allocator-independent). Fix: make them `std::atomic<int>`.

**2. Missing completion on the `stopflag` early-return.** A worker that starts *after* main has set `stopflag = TRUE` hits `if (stopflag) return 0;` and returns **without** setting `finished = TRUE`, leaving that slot's `finished` at its initial `0` forever → main spins on it. Fix: mark the slot finished before that early-return.

### Verification
- ThreadSanitizer: the `stopflag` and `finished` data races are reported before the change and gone after.
- Repro loop under a slow-thread-startup allocator: previously frequent hangs (~7/11) → **0** over 24 runs after both fixes. The atomic change alone was necessary but not sufficient — bug #2 needs the early-return fix too.

Two lines of behavioral change (`std::atomic` decls + `finished = TRUE` on early-return) plus `#include <atomic>`; no change to the benchmark's allocation behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)