### PR TITLE
Do a clean build of lean-mathlib

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -545,7 +545,9 @@ function run_test_env_cmd { # <test name> <allocator name> <environment args> <c
       popd;;
     mathlib)
       echo "preprocess..."
-      find . -name '*.olean' -delete;;
+      pushd "../lean/out/release"
+      make clean-olean
+      popd;;
     lua)
       pushd "$luadir"
       make clean

--- a/bench.sh
+++ b/bench.sh
@@ -545,9 +545,7 @@ function run_test_env_cmd { # <test name> <allocator name> <environment args> <c
       popd;;
     mathlib)
       echo "preprocess..."
-      pushd "../lean/out/release"
-      make clean-olean
-      popd;;
+      make -C ../lean/out/release clean-olean;;
     lua)
       pushd "$luadir"
       make clean


### PR DESCRIPTION
`find . -name '*.olean' -delete;;  `
The directory (extern/mathlib) does not have any .olean files, hence delete is ineffective.

Before Fix:
```
$../../bench.sh sys lean lean-mathlib
------------------------------------------------------------------
 test    alloc   time  rss    user  sys  page-faults page-reclaims
leanN       sys   13.05 245660 30.57 0.63 0 60346
mathlib     sys   **01.38** 104656 1.33 0.18 0 44799
```

After Fix:
```
$../../bench.sh sys lean lean-mathlib
------------------------------------------------------------------
# test    alloc   time  rss    user  sys  page-faults page-reclaims
leanN       sys   12.98 256568 30.51 0.70 0 63592
mathlib     sys   **13.81** 351104 30.64 1.01 0 154038
```